### PR TITLE
Enhance manage/finishers/map

### DIFF
--- a/app/controllers/manage/finishers_controller.rb
+++ b/app/controllers/manage/finishers_controller.rb
@@ -43,6 +43,15 @@ class Manage::FinishersController < Manage::ManageController
     @title = @finisher.chosen_name
   end
 
+  def card
+    @finisher = Finisher.find(params[:id])
+    respond_to do |format|
+      format.html do
+        render layout: false
+      end
+    end
+  end
+
   def edit
     @finisher = Finisher.find(params[:id])
     @title = "Edit " + @finisher.chosen_name

--- a/app/views/manage/finishers/_finisher.html.haml
+++ b/app/views/manage/finishers/_finisher.html.haml
@@ -1,37 +1,5 @@
 .col-6.col-sm-6.col-md-4.col-lg-3.col-xl-3.col-xxl-2
-  .card.mb-4
-    - if finisher.unavailable
-      .unavailable
-        Unavailable
-    .dominant-hand{ class: finisher.dominant_hand ? finisher.dominant_hand[0] : '' }
-      = finisher.dominant_hand&.first
-    - if finisher.picture.representable?
-      = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top'), [:manage, finisher]
-    - else
-      = link_to image_tag('finisher.png', class: 'card-img-top'), [:manage, finisher]
-    .card-body
-      %h6.card-title.d-flex.align-items-start
-        .flex-grow-1
-          = link_to finisher.name, [:manage, finisher]
-        - if finisher.can_publicize?
-          = fa_icon 'bullhorn'
-
-      .since
-        %b Since:
-        = l(finisher.joined_on) if finisher.joined_on
-      .skills
-        %b Skills:
-        = finisher.rated_assessments.map{|assessment| "#{assessment.skill.name} (#{assessment.rating})"}.join(', ')
-      .favorites
-        .row
-          %b.col-10 Favorites:
-          .col-2
-            %button.btn.btn-link.p-0{"data-bs-target" => "##{dom_id(finisher)}", "data-bs-toggle" => "modal", type: "button"}
-              = fa_icon('comment')
-        = finisher.products.map{|fav| fav.name}.join(', ')
-
-    .card-footer
-      #{finisher.city}, #{finisher.state}
+  = render partial: 'finisher_card', :locals => {finisher: finisher}
 
   .modal.fade{ "id" => dom_id(finisher), "aria-hidden" => "true", "aria-labelledby" => "exampleModalLabel", tabindex: "-1"}
     .modal-dialog

--- a/app/views/manage/finishers/_finisher.html.haml
+++ b/app/views/manage/finishers/_finisher.html.haml
@@ -1,5 +1,5 @@
 .col-6.col-sm-6.col-md-4.col-lg-3.col-xl-3.col-xxl-2
-  = render partial: 'finisher_card', :locals => {finisher: finisher}
+  = render partial: 'finisher_card', :locals => {finisher: finisher, classes: ['mb-4']}
 
   .modal.fade{ "id" => dom_id(finisher), "aria-hidden" => "true", "aria-labelledby" => "exampleModalLabel", tabindex: "-1"}
     .modal-dialog

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -5,9 +5,9 @@
   .dominant-hand{ class: finisher.dominant_hand ? finisher.dominant_hand[0] : '' }
     = finisher.dominant_hand&.first
   - if finisher.picture.representable?
-    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top'), [:manage, finisher]
+    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top', style: 'height:6vw; object-fit:contain'), [:manage, finisher]
   - else
-    = link_to image_tag('finisher.png', class: 'card-img-top'), [:manage, finisher]
+    = link_to image_tag('finisher.png', class: 'card-img-top', style: 'height:6vw; object-fit:contain'), [:manage, finisher]
   .card-body
     %h6.card-title.d-flex.align-items-start
       .flex-grow-1

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -1,0 +1,33 @@
+.card.mb-4
+  - if finisher.unavailable
+    .unavailable
+      Unavailable
+  .dominant-hand{ class: finisher.dominant_hand ? finisher.dominant_hand[0] : '' }
+    = finisher.dominant_hand&.first
+  - if finisher.picture.representable?
+    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top'), [:manage, finisher]
+  - else
+    = link_to image_tag('finisher.png', class: 'card-img-top'), [:manage, finisher]
+  .card-body
+    %h6.card-title.d-flex.align-items-start
+      .flex-grow-1
+        = link_to finisher.name, [:manage, finisher]
+      - if finisher.can_publicize?
+        = fa_icon 'bullhorn'
+
+    .since
+      %b Since:
+      = l(finisher.joined_on) if finisher.joined_on
+    .skills
+      %b Skills:
+      = finisher.rated_assessments.map{|assessment| "#{assessment.skill.name} (#{assessment.rating})"}.join(', ')
+    .favorites
+      .row
+        %b.col-10 Favorites:
+        .col-2
+          %button.btn.btn-link.p-0{"data-bs-target" => "##{dom_id(finisher)}", "data-bs-toggle" => "modal", type: "button"}
+            = fa_icon('comment')
+      = finisher.products.map{|fav| fav.name}.join(', ')
+
+  .card-footer
+    #{finisher.city}, #{finisher.state}

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -1,13 +1,13 @@
-.card.mb-4
+%div{:class => classes.append('card')}
   - if finisher.unavailable
     .unavailable
       Unavailable
   .dominant-hand{ class: finisher.dominant_hand ? finisher.dominant_hand[0] : '' }
     = finisher.dominant_hand&.first
   - if finisher.picture.representable?
-    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top', style: 'height:6vw; object-fit:contain'), [:manage, finisher]
+    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top', style: 'height:8vw; object-fit:contain'), [:manage, finisher]
   - else
-    = link_to image_tag('finisher.png', class: 'card-img-top', style: 'height:6vw; object-fit:contain'), [:manage, finisher]
+    = link_to image_tag('finisher.png', class: 'card-img-top', style: 'height:8vw; object-fit:contain'), [:manage, finisher]
   .card-body
     %h6.card-title.d-flex.align-items-start
       .flex-grow-1

--- a/app/views/manage/finishers/card.html.haml
+++ b/app/views/manage/finishers/card.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'finisher_card', :locals => {finisher: @finisher}

--- a/app/views/manage/finishers/card.html.haml
+++ b/app/views/manage/finishers/card.html.haml
@@ -1,1 +1,1 @@
-= render partial: 'finisher_card', :locals => {finisher: @finisher}
+= render partial: 'finisher_card', :locals => {finisher: @finisher, classes:[]}

--- a/app/views/manage/finishers/map.html.haml
+++ b/app/views/manage/finishers/map.html.haml
@@ -62,7 +62,7 @@
       const finishers = [#{ @finishers.map{|f| "{ position: { lat: #{f.latitude}, lng: #{f.longitude}}, title: '#{escape_javascript(f.name)}', skills: '#{f.rated_skills_string}', url: '/manage/finishers/#{f.id}', zIndex: #{@skill_id ? f.assessments.find_by(skill_id: @skill_id).rating : 0} }"}.join(',') }];
 
       const infowindow = new google.maps.InfoWindow({
-        maxWidth: 300,
+        maxWidth: 200,
       });
 
       finishers.forEach(finisher => {

--- a/app/views/manage/finishers/map.html.haml
+++ b/app/views/manage/finishers/map.html.haml
@@ -18,8 +18,13 @@
   .col#map{ style: "height:500px; flex: 1"}
 
 - if @finishers
-  .row
-    = render @finishers.first(48)
+  %table.table
+    %thead
+      %tr
+        %th Name
+        %th Email
+        %th Address
+      = render partial: 'finisher_row', collection: @finishers, as: :finisher
 
   = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{Rails.application.credentials.dig(:google, :maps_api_key)}&callback=initMap", defer: true
 
@@ -56,14 +61,12 @@
 
       const finishers = [#{ @finishers.map{|f| "{ position: { lat: #{f.latitude}, lng: #{f.longitude}}, title: '#{escape_javascript(f.name)}', skills: '#{f.rated_skills_string}', url: '/manage/finishers/#{f.id}', zIndex: #{@skill_id ? f.assessments.find_by(skill_id: @skill_id).rating : 0} }"}.join(',') }];
 
+      const infowindow = new google.maps.InfoWindow({
+        maxWidth: 300,
+      });
 
       finishers.forEach(finisher => {
         const content = `<div><h3>${finisher.title}</h3><div><a href='${finisher.url}' target='_blank'>Profile</a></div><p>${finisher.skills}</p></div>`;
-
-        const infowindow = new google.maps.InfoWindow({
-          content: content,
-          ariaLabel: "Uluru",
-        });
 
         const pinColor = finisher.zIndex === 3 ? "#22bc49" : finisher.zIndex === 2 ? "#dcce1f" : finisher.zIndex === 1 ? "#e72d2d" : "#3975EC";
 
@@ -87,12 +90,13 @@
         const marker = new google.maps.Marker({ ...finisher, icon, label, map, optimized: false });
 
         marker.addListener("click", () => {
-          infowindow.open({
-            anchor: marker,
-            map,
-          });
+          fetch(`http://localhost:3000${finisher.url}/card`)
+            .then(response => response.text())
+            .then(html => {
+              infowindow.setContent(html);
+              infowindow.open({anchor: marker, map}); })
+            .catch(error => { console.log(error)});
         });
-
       });
     }
 

--- a/app/views/manage/finishers/map.html.haml
+++ b/app/views/manage/finishers/map.html.haml
@@ -66,8 +66,6 @@
       });
 
       finishers.forEach(finisher => {
-        const content = `<div><h3>${finisher.title}</h3><div><a href='${finisher.url}' target='_blank'>Profile</a></div><p>${finisher.skills}</p></div>`;
-
         const pinColor = finisher.zIndex === 3 ? "#22bc49" : finisher.zIndex === 2 ? "#dcce1f" : finisher.zIndex === 1 ? "#e72d2d" : "#3975EC";
 
         const icon = {
@@ -90,7 +88,7 @@
         const marker = new google.maps.Marker({ ...finisher, icon, label, map, optimized: false });
 
         marker.addListener("click", () => {
-          fetch(`http://localhost:3000${finisher.url}/card`)
+          fetch(`${finisher.url}/card`)
             .then(response => response.text())
             .then(html => {
               infowindow.setContent(html);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       collection do
         get 'map'
       end
+      get 'card', on: :member
     end
   end
 


### PR DESCRIPTION
This pr adds a finisher card view to the map info window displayed when a user selects a pin on a map.  It also adds a table under the map instead of a card listing of finishers.

- Created a card partial
- Created a `manage/finishers/{finisher_id}/card` route to be used by map js to display info window
- Moved info window instantiation out side of for loop that was preventing auto closure and multiple server requests in new generation.

 
<img width="1561" alt="Screenshot 2023-11-21 at 11 34 30 AM" src="https://github.com/looseendsproject/webapp/assets/223519/1747169e-1beb-4665-a3a2-38143cc2887b">
