### PR TITLE
adjust css for image in card

### DIFF
--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -5,9 +5,9 @@
   .dominant-hand{ class: finisher.dominant_hand ? finisher.dominant_hand[0] : '' }
     = finisher.dominant_hand&.first
   - if finisher.picture.representable?
-    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top', style: 'height:8vw; object-fit:contain'), [:manage, finisher]
+    = link_to image_tag(finisher.picture.representation( resize_to_limit: [300, 300]), class: 'card-img-top', style: 'height:8vw; object-fit:cover;'), [:manage, finisher]
   - else
-    = link_to image_tag('finisher.png', class: 'card-img-top', style: 'height:8vw; object-fit:contain'), [:manage, finisher]
+    = link_to image_tag('finisher.png', class: 'card-img-top', style: 'height:8vw; object-fit:cover;'), [:manage, finisher]
   .card-body
     %h6.card-title.d-flex.align-items-start
       .flex-grow-1


### PR DESCRIPTION
Image styling tweak for card. 

OLD:
<img width="228" alt="Screenshot 2023-11-21 at 9 58 12 PM" src="https://github.com/looseendsproject/webapp/assets/223519/8987bf98-8ce8-45f2-a1dc-55f76d43d59c">

NEW:
<img width="228" alt="Screenshot 2023-11-21 at 9 58 35 PM" src="https://github.com/looseendsproject/webapp/assets/223519/430de654-3505-48d9-86cb-821a0b7092ca">
