### PR TITLE
Make finishers headshots higher resolution [sc-17]

### DIFF
--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -27,12 +27,7 @@
 
     - if @finisher.picture.representable?
       .page_section.mb-2
-        = image_tag @finisher.picture.representation( resize_to_limit: [300, 300]), class: 'w-100'
-      .page_section.mb-2
-        %a{href: rails_blob_path(@finisher.picture, disposition: "attachment", only_path: true), class: 'btn btn-sm btn-outline-secondary'}
-          Download Image
-          %span
-            %i.bi.bi-download
+        = link_to image_tag(@finisher.picture.representation( resize_to_limit: [300, 300]), class: 'w-100'), url_for(@finisher.picture.variant(format: :jpg))
 
     .page-section.mb-2
       %b Email:

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -26,7 +26,12 @@
       = @finisher.user.heard_about_us
 
     - if @finisher.picture.representable?
-      = image_tag @finisher.picture.representation( resize_to_limit: [300, 300]), class: 'w-100'
+      .page_section
+        = image_tag @finisher.picture.representation( resize_to_limit: [300, 300]), class: 'w-100'
+      .page_section
+        %a{href: rails_blob_path(@finisher.picture, disposition: "attachment", only_path: true), class: 'btn btn-sm btn-outline-secondary mt-2 mb-2'}
+          %span.bi.bi-download &nbsp;Download Image
+
     .page-section
       %b Email
       = @finisher.user.email

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -11,40 +11,42 @@
 
 .row
   .col-3
-    %div
-      Publicize:
+    .page_section.mb-2
+      %b Publicize:
       = fa_icon @finisher.can_publicize? ? 'bullhorn' : 'xmark'
 
-    %div
-      Dominant Hand:
+    .page_section.mb-2
+      %b Dominant Hand:
       = @finisher.dominant_hand
-    %div
-      Since:
+    .page_section.mb-2
+      %b Since:
       = @finisher.joined_on
-    %div
-      How Heard:
+    .page_section.mb-2
+      %b How Heard:
       = @finisher.user.heard_about_us
 
     - if @finisher.picture.representable?
-      .page_section
+      .page_section.mb-2
         = image_tag @finisher.picture.representation( resize_to_limit: [300, 300]), class: 'w-100'
-      .page_section
-        %a{href: rails_blob_path(@finisher.picture, disposition: "attachment", only_path: true), class: 'btn btn-sm btn-outline-secondary mt-2 mb-2'}
-          %span.bi.bi-download &nbsp;Download Image
+      .page_section.mb-2
+        %a{href: rails_blob_path(@finisher.picture, disposition: "attachment", only_path: true), class: 'btn btn-sm btn-outline-secondary'}
+          Download Image
+          %span
+            %i.bi.bi-download
 
-    .page-section
-      %b Email
+    .page-section.mb-2
+      %b Email:
       = @finisher.user.email
-    .page-section
-      %b Phone Number
+    .page-section.mb-2
+      %b Phone Number:
       = @finisher.phone_number
-    .page-section
-      %b Pronouns
+    .page-section.mb-2
+      %b Pronouns:
       = @finisher.pronouns
-    .page-section
+    .page-section.mb-2
       .row
         .col
-          %b Mailing Address
+          %b Mailing Address:
         .col.text-end= link_to fa_icon('map'), "https://maps.google.com/?q=#{@finisher.full_address}", target: "_blank"
       .street= @finisher.street
       - if @finisher.street_2.present?


### PR DESCRIPTION
- when clicking on a the finisher photo it opens the full resolution photo in a new tab
- added some styling tweaks to first column to make spacing and bold font consistent

<img width="1129" alt="Screenshot 2023-11-24 at 9 21 14 AM" src="https://github.com/looseendsproject/webapp/assets/223519/feef3718-10cc-4cd4-b295-2cad3bd201bf">


