### PR TITLE
Can we put optional next to optional questions [sc-41]

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -51,9 +51,18 @@
 
 
 .required:after
-  font-size: 1.2rem
-  content: "*"
+  font-size: 1rem
+  content: "*required"
   color: orangered
+  position: relative
+  bottom: 0
+  left: 2px
+  line-height: 1.2
+
+.optional:after
+  font-size: 1rem
+  content: "(optional)"
+  color: grey
   position: relative
   bottom: 0
   left: 2px

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -21,7 +21,7 @@
       = f.email_field :email, autocomplete: "email", class: 'form-control'
   .row.g-1.g-sm-4
     .col-12.col-sm-10.col-md-8
-      = f.label 'Where did you hear about us?', class: 'col-form-label'
+      = f.label 'Where did you hear about us?', class: 'col-form-label optional'
       = f.text_area :heard_about_us, size: "60x4", class: 'form-control'
   .row.g-1.g-sm-4
     .col-12.col-sm-10.col-md-8

--- a/app/views/finishers/_favorites_form.html.haml
+++ b/app/views/finishers/_favorites_form.html.haml
@@ -14,18 +14,18 @@
                 (#{b.object.description})
   .row.g-1.g-sm-4.mb-3
     .col-12.col-md-9
-      = form.label 'Do you have favorites?', class: 'form-label'
+      = form.label 'Do you have favorites?', class: 'form-label optional'
       = form.text_area :other_favorites, size: "60x3", class: 'form-control'
   .row.g-1.g-sm-4.mb-3
     .col-12.col-md-9
-      = form.label "Things you've finished", class: 'form-label'
+      = form.label "Things you've finished", class: 'form-label optional'
       .form-info Please upload photos of things you'd like to show off!
       = form.file_field :append_finished_projects, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp",  :multiple => true
       - form.object.finished_projects.each do |image|
         = image_tag image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'
   .row.g-1.g-sm-4.mb-3.mb-3
     .col-12.col-md-9
-      %b= form.label 'Please, Never Again!', class: 'form-label'
+      %b= form.label 'Please, Never Again!', class: 'form-label optional'
       .form-info Are there techniques or projects you would rather avoid?
       = form.text_area :dislikes, size: "60x3", class: 'form-control'
 

--- a/app/views/finishers/_profile_form.html.haml
+++ b/app/views/finishers/_profile_form.html.haml
@@ -5,7 +5,7 @@
       = form.label 'Name', class: 'form-label required'
       = form.text_field :chosen_name, class: 'form-control'
     .col-12.col-xl-2.col-lg-3.col-md-4
-      = form.label 'Pronouns', class: 'form-label'
+      = form.label 'Pronouns', class: 'form-label optional'
       = form.text_field :pronouns, class: 'form-control'
   .row.g-1.g-sm-4
     .col-12.col-xl-4.col-lg-5.col-md-6
@@ -23,11 +23,11 @@
           = image_tag @finisher.picture.representation( resize_to_limit: [200, 200])
   .row.g-1.g-sm-4.mb-4
     .col-xl-6.col-lg-8.col-md-10
-      = form.label 'A Photo of you', class: 'form-label'
+      = form.label 'A Photo of you', class: 'form-label optional'
       = form.file_field :picture, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp"
   .row.g-1.g-sm-4.mb-4
     .col-xl-6.col-lg-8.col-md-10
-      = form.label 'Social Media', class: 'form-label'
+      = form.label 'Social Media', class: 'form-label optional'
       .form-info Use this space to share your Ravelry, Instagram or Facebook account (optional).
       = form.text_area :social_media, size: "60x3", class: 'form-control'
   .row.g-1.g-sm-4.mb-4
@@ -36,7 +36,7 @@
       = form.select :has_workplace_match, [['Yes', true], ['No', false], ["I don't know", nil]], {}, {:class => 'form-select'}
   .row.g-1.g-sm-4.mb-4
     .col-12.col-xl-4.col-lg-5.col-md-6
-      = form.label 'If you do work outside the home what company do you work for?', class: 'form-label'
+      = form.label 'If you do work outside the home what company do you work for?', class: 'form-label optional'
       = form.text_field :workplace_name, class: 'form-control'
 
   .row.g-1.g-sm-4

--- a/app/views/finishers/_skills_form.html.haml
+++ b/app/views/finishers/_skills_form.html.haml
@@ -19,7 +19,7 @@
               = assessment_form.text_field :description, class: 'ml-2 form-control', placeholder: "Tell us more..."
   .row.g-1.g-sm-4.mb-3
     .col-12.col-sm-10.col-md-8
-      = form.label 'Other Skills?', class: 'form-label'
+      = form.label 'Other Skills?', class: 'form-label optional'
       .form-info Are there other crafts you love to do that we should know about?
       = form.text_area :other_skills, size: "60x3", class: 'form-control'
   .row.mb-3
@@ -30,7 +30,7 @@
       = form.select :dominant_hand, ['Lefty', 'Righty', 'Either Hand'], { include_blank: true}, { class: 'form-select' }
   .row.mb-3
     .col-12
-      = form.label 'Tell us about your home', class: 'form-label'
+      = form.label 'Tell us about your home', class: 'form-label optional'
     .col-6.col-sm-5.col-md-4
       .form-info Do you have pets in your home?
       = form.collection_check_boxes(:in_home_pets, [ ['Dog(s)', 'dogs'], ['Cat(s)', 'cats'], ['Other', 'other'] ], :last, :first) do |b|
@@ -48,7 +48,7 @@
 
   .row.g-1.g-sm-4.mb-3
     .col-12
-      = form.label 'Sensitivities', class: 'form-label'
+      = form.label 'Sensitivities', class: 'form-label optional'
       .form-info If we find out an unfinished project was in a house with a smoker or pets, do you want to avoid this project?
       .row
         %label.form-label

--- a/app/views/layouts/_address_form.html.haml
+++ b/app/views/layouts/_address_form.html.haml
@@ -8,7 +8,7 @@
       = form.text_field :street, class: 'form-control'
   .row.my-2
     .col-12.col-md-10.col-lg-8
-      = form.label 'Line 2', class: 'form-label'
+      = form.label 'Line 2', class: 'form-label optional'
       = form.text_field :street_2, class: 'form-control'
   .row.my-2
     .col-4.col-lg-3


### PR DESCRIPTION
<img width="1218" alt="Screenshot 2023-12-06 at 6 17 17 PM" src="https://github.com/looseendsproject/webapp/assets/223519/9f28c23d-4fcc-410c-8192-60ff4ee54015">
<img width="1218" alt="Screenshot 2023-12-06 at 6 17 45 PM" src="https://github.com/looseendsproject/webapp/assets/223519/e4cc4e4c-2283-4d16-8605-da4378fb669c">
<img width="1218" alt="Screenshot 2023-12-06 at 6 17 57 PM" src="https://github.com/looseendsproject/webapp/assets/223519/41ee785e-49ae-4d2d-9a41-9d9b420811c1">
<img width="1218" alt="Screenshot 2023-12-06 at 6 18 14 PM" src="https://github.com/looseendsproject/webapp/assets/223519/331ede34-d2cb-45c2-88fb-10a2d0d330c8">
