### PR TITLE
Sort Skill and Product dropdowns

### DIFF
--- a/app/views/manage/finishers/_search.html.haml
+++ b/app/views/manage/finishers/_search.html.haml
@@ -30,9 +30,9 @@
     .col
   .row.mb-4
     .col
-      = select_tag :skill_id, options_from_collection_for_select(Skill.all, "id", "name", params[:skill_id]), include_blank: true, class: 'form-select'
+      = select_tag :skill_id, options_from_collection_for_select(Skill.sorted_by_popularity, "id", "name", params[:skill_id]), include_blank: true, class: 'form-select'
     .col
-      = select_tag :product_id, options_from_collection_for_select(Product.all, "id", "name", params[:product_id]), include_blank: true, class: 'form-select'
+      = select_tag :product_id, options_from_collection_for_select(Product.order(:name), "id", "name", params[:product_id]), include_blank: true, class: 'form-select'
     .col
       = select_tag :country, options_for_select(@countries, params[:country]), include_blank: true, class: 'form-select'
     .col


### PR DESCRIPTION
Adds the new sorted_by_popularity and order(:name) to Skill and Product drop downs

<img width="242" alt="image" src="https://github.com/looseendsproject/webapp/assets/31340/10c30b51-b32a-4f0e-900e-763eca012f1d">

<img width="220" alt="image" src="https://github.com/looseendsproject/webapp/assets/31340/05960a2a-6275-4dd1-abdf-f73cd27dc3b3">
