### PR TITLE
Adding project managers to projects

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < Admin::AdminController
   private
 
   def user_params
-    params.require(:user).permit(:role, :email)
+    params.require(:user).permit(:role, :email, :is_project_manager)
   end
 
 end

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -7,6 +7,9 @@ class Manage::ProjectsController < Manage::ManageController
     if (params[:assigned].present?)
       @projects = @projects.has_assigned(params[:assigned])
     end
+    if (params[:project_manager].present?)
+      @projects = @projects.where(manager_id: params[:project_manager])
+    end
     @projects = @projects.paginate(page: params[:page])
   end
 
@@ -44,6 +47,7 @@ class Manage::ProjectsController < Manage::ManageController
 
   def project_params
     params.require(:project).permit(
+      :manager_id,
       :name,
       :description,
       :more_details,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,6 +2,7 @@ class Project < ApplicationRecord
 
   STATUSES = ['proposed', 'approved', 'in progress', 'finished']
 
+  belongs_to :manager, optional: true, class_name: 'User'
   belongs_to :user, optional: true
   has_many :assignments
   has_many :finishers, through: :assignments
@@ -13,7 +14,6 @@ class Project < ApplicationRecord
   has_many_attached :material_images
 
   before_validation :set_default_status
-
 
   validates :status, inclusion: { in: STATUSES }
   validates :status, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def self.project_managers
+    where(role: %w[admin manager], is_project_manager: true)
+  end
+
   def admin?
     role == 'admin'
   end

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -4,6 +4,9 @@
     .col-4
       = form.label 'Role', class: 'form-label'
       = form.select :role, [['User', 'user'], ['Manager', 'manager'], ['Admin', 'admin']], { }, { class: 'form-select' }
+    .col-4
+      = form.check_box :is_project_manager, class: 'form-check-input'
+      = form.label :is_project_manager, class: 'form-check-label'
   .row
     .col-4
       = form.label 'Email', class: 'form-label'

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -8,4 +8,4 @@
   .col
     Email: #{@user.email}
 %p
-  Role: #{@user.role}
+  Role: #{@user.role} #{@user.is_project_manager ? '(Matcher)' : ''}

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -4,9 +4,12 @@
     .col-6
       = form.label 'Give this project a name', class: 'form-label required'
       = form.text_field :name, class: 'form-control'
-    .col-4
+    .col-2
       = form.label :status, class: 'form-label'
       = form.select :status, Project::STATUSES.map{ |status| [status.humanize, status ]}, { }, { class: 'form-select' }
+    .col-2
+      = form.label :manager_id, class: 'form-label'
+      = form.select :manager_id, User.project_managers.map { |a| [a.name, a.id] }, { include_blank: true }, { class: 'form-select' }
 
   .row.mb-4
     .col-6

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -9,11 +9,15 @@
     .col
       Assigned:
     .col
+      Manager:
+    .col
   .row.mb-4
     .col
       = select_tag :status, options_for_select(Project::STATUSES.map{ |status| [status.humanize, status ]}, params[:status]), include_blank: true, class: 'form-select'
     .col
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
+    .col
+      = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
     .col
       = submit_tag "Search", name: nil, class: 'btn btn-primary'
 

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -58,9 +58,9 @@
     %h3
       Assignees
       .float-end
-        = link_to 'Search for Finisher', [:manage, @project, :finishers, { state: @project.state, country: @project.country }], class: 'btn btn-outline-secondary'
+        = link_to 'Search', [:manage, @project, :finishers, { state: @project.state, country: @project.country }], class: 'btn btn-outline-secondary'
         - if @project.state.present? && @project.country.present?
-          = link_to 'Find on Map', [:map, :manage, @project, :finishers, { near: @project.full_address, radius: 50 }], class: 'btn btn-outline-secondary'
+          = link_to 'Map', [:map, :manage, @project, :finishers, { near: @project.full_address, radius: 50 }], class: 'btn btn-outline-secondary'
     = render @project.assignments
   .col-3
     %h3 Notes

--- a/db/migrate/20240326024112_add_manager_to_projects.rb
+++ b/db/migrate/20240326024112_add_manager_to_projects.rb
@@ -1,0 +1,6 @@
+class AddManagerToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :projects, :manager, foreign_key: { to_table: :users }
+    add_column :users, :is_project_manager, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_25_015308) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_26_024112) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,8 +185,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_25_015308) do
     t.string "crafter_dominant_hand"
     t.float "latitude"
     t.float "longitude"
+    t.bigint "manager_id"
     t.index ["latitude"], name: "index_projects_on_latitude"
     t.index ["longitude"], name: "index_projects_on_longitude"
+    t.index ["manager_id"], name: "index_projects_on_manager_id"
     t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
@@ -216,10 +218,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_25_015308) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_project_manager"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "projects", "users", column: "manager_id"
 end


### PR DESCRIPTION
This adds Project Managers to projects

Adding manager_id foreign key, exposing as `belongs_to :manager` (a User) in project
Adding is_project_manager boolean to User

Enabled editing these fields on the Project and User, respectively.

<img width="206" alt="image" src="https://github.com/looseendsproject/webapp/assets/31340/1a352068-7f46-4247-96a5-f716c2382644">

<img width="619" alt="image" src="https://github.com/looseendsproject/webapp/assets/31340/bf2d0c6a-b4dd-474d-9e57-d6920dbadadc">

<img width="1120" alt="image" src="https://github.com/looseendsproject/webapp/assets/31340/88e182d9-0ab5-4f22-9618-35e5c7b412c0">


Allowing for filtering in the Project search, to return projects managed by a particular user.  We can make custom dashboard views per manager.

