### PR TITLE
Restore volunteers in migration files before change to finishers

### DIFF
--- a/db/migrate/20230108181958_create_volunteers.rb
+++ b/db/migrate/20230108181958_create_volunteers.rb
@@ -1,6 +1,6 @@
-class CreateFinishers < ActiveRecord::Migration[7.0]
+class CreateVolunteers < ActiveRecord::Migration[7.0]
   def change
-    create_table :finishers do |t|
+    create_table :volunteers do |t|
 
       t.string :chosen_name
       t.string :pronouns

--- a/db/migrate/20230108182812_create_assignments.rb
+++ b/db/migrate/20230108182812_create_assignments.rb
@@ -2,7 +2,7 @@ class CreateAssignments < ActiveRecord::Migration[7.0]
   def change
     create_table :assignments do |t|
       t.references :project
-      t.references :finisher
+      t.references :volunteer
       t.references :user             # Assigner
       t.datetime :ended_at
       t.datetime :started_at

--- a/db/migrate/20230108184735_create_assessments.rb
+++ b/db/migrate/20230108184735_create_assessments.rb
@@ -2,7 +2,7 @@ class CreateAssessments < ActiveRecord::Migration[7.0]
   def change
     create_table :assessments do |t|
       t.references :skill
-      t.references :finisher
+      t.references :volunteer
       t.integer :rating, null: false
       t.text :description
       t.timestamps

--- a/db/migrate/20230816225430_add_joined_on_to_volunteers.rb
+++ b/db/migrate/20230816225430_add_joined_on_to_volunteers.rb
@@ -1,6 +1,6 @@
 class AddJoinedOnToVolunteers < ActiveRecord::Migration[7.0]
   def change
-    add_column :finishers, :joined_on, :date
-    add_index :finishers, :joined_on
+    add_column :volunteers, :joined_on, :date
+    add_index :volunteers, :joined_on
   end
 end


### PR DESCRIPTION
I'm not sure if this PR is still required. Please advise!

The goal of the PR was to restore the migration files to preserve the term `volunteers` in all files before `20230910220917_change_volunteers_to_finishers.rb`. Since the migration files had been edited to replace `volunteers` with `finishers`, it wasn't possible to run the migrations after a fresh `db:create`. However, if new dev environments should be set up using `db:schema:load`, this PR isn't necessary because `db:schema:load` works just fine without these changes. I would only push to merge this change if there's a case for needing to be able to run `db:migrate`.

Here are some snapshots of the DB tables after the changes in this PR, showing that everything resolves to reference `finishers` instead of `volunteers`:
<img width="133" alt="image" src="https://github.com/looseendsproject/webapp/assets/26069560/507eef3b-f4cd-40ff-97f8-ac87f40080e9">
<img width="125" alt="image" src="https://github.com/looseendsproject/webapp/assets/26069560/553a75db-cd5c-458d-b3c5-aeae833f412f">
<img width="201" alt="image" src="https://github.com/looseendsproject/webapp/assets/26069560/0a935f2e-16ae-433a-84a9-75379cb70d1a">
