### PR TITLE
Add filter to finisher search for has workplace match

### DIFF
--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -128,6 +128,9 @@ class Finisher < ApplicationRecord
     if params[:country].present?
       @results = @results.where(:country => params[:country])
     end
+    if params[:has_workplace_match].present? && params[:has_workplace_match] == '1'
+      @results = @results.where(has_workplace_match: true)
+    end
     return @results
   end
 

--- a/app/views/manage/finishers/_search.html.haml
+++ b/app/views/manage/finishers/_search.html.haml
@@ -28,6 +28,8 @@
     .col
       = label_tag :search, "State", class: 'label'
     .col
+      = label_tag :has_workplace_match, "Has Workplace Match", class: 'label'
+    .col
   .row.mb-4
     .col
       = select_tag :skill_id, options_from_collection_for_select(Skill.sorted_by_popularity, "id", "name", params[:skill_id]), include_blank: true, class: 'form-select'
@@ -37,6 +39,9 @@
       = select_tag :country, options_for_select(@countries, params[:country]), include_blank: true, class: 'form-select'
     .col
       = select_tag :state, options_for_select(@states, params[:state]), include_blank: true, class: 'form-select'
+    .col
+      = check_box_tag :has_workplace_match, '1', params[:has_workplace_match] == '1', class: 'form-check-input'
+      = label_tag :has_workplace_match, "Yes", class: 'form-check-label'
     .col
       .row
         .col

--- a/app/views/manage/finishers/_search.html.haml
+++ b/app/views/manage/finishers/_search.html.haml
@@ -28,7 +28,7 @@
     .col
       = label_tag :search, "State", class: 'label'
     .col
-      = label_tag :has_workplace_match, "Has Workplace Match", class: 'label'
+      = label_tag :has_workplace_match, "Employer Match", class: 'label'
     .col
   .row.mb-4
     .col


### PR DESCRIPTION
Adds a filter for "Employer Match" to the /manage/finishers search view.

Not filtered by "Employer Match" (there are 3 finishers in my DB):
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e4f0ee63-c411-42a4-93b5-213e438d2236">

Filtered by "Employer Match" (there are 2 finishers in my DB with has_workplace_match set to true):
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/da1369de-a38d-400f-bc34-92447bfd2922">
