### PR TITLE
Add all possible project statuses

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -4,7 +4,7 @@ class Manage::ProjectsController < Manage::ManageController
     if (params[:status].present?)
       @projects = Project.has_status(params[:status])
     else
-      @projects = Project.has_status(['proposed', 'breakup/decline', 'on hold', 'project confirmation email sent/ready to match',
+      @projects = Project.has_status(['proposed', 'on hold', 'project confirmation email sent/ready to match',
       'finisher invited', 'rematch', 'project accepted', 'introduced', 'humming along', 'unresponsive',
       'f2f rematch'])
     end

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -4,7 +4,9 @@ class Manage::ProjectsController < Manage::ManageController
     if (params[:status].present?)
       @projects = Project.has_status(params[:status])
     else
-      @projects = Project.has_status(['proposed', 'approved', 'in progress'])
+      @projects = Project.has_status(['proposed', 'breakup/decline', 'on hold', 'project confirmation email sent/ready to match',
+      'finisher invited', 'rematch', 'project accepted', 'introduced', 'humming along', 'unresponsive',
+      'f2f rematch'])
     end
     if (params[:assigned].present?)
       @projects = @projects.has_assigned(params[:assigned])

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,10 @@
 class Project < ApplicationRecord
 
-  STATUSES = ['draft', 'proposed', 'approved', 'in progress', 'finished']
+  STATUSES = [
+    'draft', 'proposed', 'breakup/decline', 'on hold', 'project confirmation email sent/ready to match',
+    'finisher invited', 'rematch', 'project accepted', 'introduced', 'humming along', 'unresponsive',
+    'f2f rematch', 'done'
+  ]
 
   belongs_to :manager, optional: true, class_name: 'User'
   belongs_to :user, optional: true
@@ -56,16 +60,48 @@ class Project < ApplicationRecord
     where({ status: 'proposed' })
   end
 
-  def self.approved
-    where({ status: 'approved' })
+  def self.breakup_decline
+    where({ status: 'breakup/decline' })
   end
 
-  def self.in_progress
-    where({ status: 'in progress' })
+  def self.on_hold
+    where({ status: 'on hold' })
   end
 
-  def self.finished
-    where({ status: 'finished' })
+  def self.project_confirmation_email_sent_ready_to_match
+    where({ status: 'project confirmation email sent/ready to match' })
+  end
+
+  def self.finisher_invited
+    where({ status: 'finisher invited' })
+  end
+
+  def self.rematch
+    where({ status: 'rematch' })
+  end
+
+  def self.project_accepted
+    where({ status: 'project accepted' })
+  end
+
+  def self.introduced
+    where({ status: 'introduced' })
+  end
+
+  def self.humming_along
+    where({ status: 'humming along' })
+  end
+
+  def self.unresponsive
+    where({ status: 'unresponsive' })
+  end
+
+  def self.f2f_rematch
+    where({ status: 'f2f rematch' })
+  end
+
+  def self.done
+    where({ status: 'done' })
   end
 
   def self.has_status (status_state)

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -21,6 +21,6 @@
     .col-2
       Proposed: #{Project.proposed.count}
     .col-2
-      In Progress: #{Project.breakup_decline.count + Project.on_hold.count + Project.project_confirmation_email_sent_ready_to_match.count + Project.finisher_invited.count + Project.rematch.count + Project.project_accepted.count + Project.introduced.count + Project.humming_along.count + Project.unresponsive.count + Project.f2f_rematch.count}
+      In Progress: #{Project.on_hold.count + Project.project_confirmation_email_sent_ready_to_match.count + Project.finisher_invited.count + Project.rematch.count + Project.project_accepted.count + Project.introduced.count + Project.humming_along.count + Project.unresponsive.count + Project.f2f_rematch.count}
     .col-2
       Done: #{Project.done.count}

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -21,8 +21,6 @@
     .col-2
       Proposed: #{Project.proposed.count}
     .col-2
-      Approved: #{Project.approved.count}
+      In Progress: #{Project.breakup_decline.count + Project.on_hold.count + Project.project_confirmation_email_sent_ready_to_match.count + Project.finisher_invited.count + Project.rematch.count + Project.project_accepted.count + Project.introduced.count + Project.humming_along.count + Project.unresponsive.count + Project.f2f_rematch.count}
     .col-2
-      In Progress: #{Project.in_progress.count}
-    .col-2
-      Finished: #{Project.finished.count}
+      Done: #{Project.done.count}


### PR DESCRIPTION
Adds all possible project statuses from the current spreadsheet to the web app.

Note: I tested out giving an existing test project of mine one of the phased-out statuses ('approved'), then making the code change to the new list of statuses. The test project still showed as having the old status in the app, but I was then able to apply a new status to it. If this is acceptable, we shouldn't need to do anything fancy to update all existing phased-out statuses to the new ones.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1c4c514d-0676-4344-a05f-2be9e7064112">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a7771bbc-9375-419d-aaf3-efb181fb91ca">
