### PR TITLE
Add new statuses to projects

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -4,6 +4,11 @@ class Manage::ProjectsController < Manage::ManageController
     @status = params[:status] || 'ready to match'
     if (params[:status].present?)
       @projects = Project.has_status(params[:status])
+
+      # Additional filter for `ready_status` if `status` is "ready to match"
+      if params[:status] == 'ready to match' && params[:ready_status].present?
+        @projects = @projects.where(ready_status: params[:ready_status])
+      end
     else
       @projects = Project.has_status([
         'drafted',

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -1,10 +1,28 @@
 class Manage::ProjectsController < Manage::ManageController
   def index
     @title = "Loose Ends - Manage - Projects"
+    @status = params[:status] || 'ready to match'
     if (params[:status].present?)
       @projects = Project.has_status(params[:status])
     else
-      @projects = Project.has_status(['proposed', 'approved', 'in progress'])
+      @projects = Project.has_status([
+        'drafted',
+        'proposed',
+        'submitted via google',
+        'project confirm email sent',
+        'ready to match',
+        'finisher invited',
+        'project accepted/waiting on terms',
+        'introduced',
+        'in process',
+        'finished/not returned',
+        'done',
+        'unresponsive',
+        'on hold',
+        'will not do',
+        'waiting for return to rematch',
+        'weird circumstance'
+      ])
     end
     if (params[:assigned].present?)
       @projects = @projects.has_assigned(params[:assigned])
@@ -65,6 +83,7 @@ class Manage::ProjectsController < Manage::ManageController
       :description,
       :more_details,
       :status,
+      :ready_status,
       :street,
       :street_2,
       :city,

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -9,6 +9,11 @@ class Manage::ProjectsController < Manage::ManageController
       if params[:status] == 'ready to match' && params[:ready_status].present?
         @projects = @projects.where(ready_status: params[:ready_status])
       end
+
+      # Additional filter for `in_process_status` if `status` is "in process"
+      if params[:status] == 'in process' && params[:in_process_status].present?
+        @projects = @projects.where(in_process_status: params[:in_process_status])
+      end
     else
       @projects = Project.has_status([
         'drafted',
@@ -89,6 +94,7 @@ class Manage::ProjectsController < Manage::ManageController
       :more_details,
       :status,
       :ready_status,
+      :in_process_status,
       :street,
       :street_2,
       :city,

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,4 +5,6 @@
 import { application } from "./application"
 
 import HelloController from "./hello_controller"
+import ToggleReadyStatus from "./toggle_ready_status"
 application.register("hello", HelloController)
+application.register("toggle-ready-status", ToggleReadyStatus)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,6 +5,6 @@
 import { application } from "./application"
 
 import HelloController from "./hello_controller"
-import ToggleReadyStatus from "./toggle_ready_status"
+import ToggleStatusController from "./toggle_status_controller"
 application.register("hello", HelloController)
-application.register("toggle-ready-status", ToggleReadyStatus)
+application.register("toggle-status", ToggleStatusController)

--- a/app/javascript/controllers/toggle_ready_status.js
+++ b/app/javascript/controllers/toggle_ready_status.js
@@ -1,0 +1,18 @@
+document.addEventListener('turbo:load', function() {
+  const statusDropdown = document.getElementById('status-dropdown');
+  const readyStatusRow = document.getElementById('ready-status-row');
+
+  function toggleReadyStatus() {
+    if (statusDropdown.value === 'ready to match') {
+      readyStatusRow.style.display = 'block';
+    } else {
+      readyStatusRow.style.display = 'none';
+    }
+  }
+
+  // Check the initial status on page load
+  toggleReadyStatus();
+  
+  // Add event listener for changes in the status dropdown
+  statusDropdown.addEventListener('change', toggleReadyStatus);
+});

--- a/app/javascript/controllers/toggle_status_controller.js
+++ b/app/javascript/controllers/toggle_status_controller.js
@@ -1,12 +1,18 @@
 document.addEventListener('turbo:load', function() {
   const statusDropdown = document.getElementById('status-dropdown');
   const readyStatusRow = document.getElementById('ready-status-row');
+  const inProcessStatusRow = document.getElementById('in-process-status-row');
 
   function toggleReadyStatus() {
     if (statusDropdown.value === 'ready to match') {
+      inProcessStatusRow.style.display = 'none';
       readyStatusRow.style.display = 'block';
+    } else if (statusDropdown.value === 'in process') {
+      readyStatusRow.style.display = 'none';
+      inProcessStatusRow.style.display = 'block';
     } else {
       readyStatusRow.style.display = 'none';
+      inProcessStatusRow.style.display = 'none';
     }
   }
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -140,6 +140,10 @@ class Project < ApplicationRecord
     where({ status: status_state })
   end
 
+  def self.has_ready_status(status)
+    where(ready_status: status)
+  end
+
   def self.has_assigned (assigned_state)
     if (assigned_state === 'true')
       joins(:assignments).distinct

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,30 @@
 class Project < ApplicationRecord
+  STATUSES = [
+    'drafted',
+    'proposed',
+    'submitted via google',
+    'project confirm email sent',
+    'ready to match',
+    'finisher invited',
+    'project accepted/waiting on terms',
+    'introduced',
+    'in process',
+    'finished/not returned',
+    'done',
+    'unresponsive',
+    'on hold',
+    'will not do',
+    'waiting for return to rematch',
+    'weird circumstance'
+  ].freeze
 
-  STATUSES = ['draft', 'proposed', 'approved', 'in progress', 'finished']
+  READY_TO_MATCH_STATUSES = [
+    'new',
+    'new - additional attempt',
+    'new - needs to go on facebook',
+    'old - needs match with a second skill',
+    'old - finisher requested rematch'
+  ].freeze
 
   belongs_to :manager, optional: true, class_name: 'User'
   belongs_to :user, optional: true
@@ -39,13 +63,13 @@ class Project < ApplicationRecord
   after_update :move_to_proposed
 
   def move_to_proposed
-    if !missing_information? && status == 'draft'
+    if !missing_information? && status == 'drafted'
       update_column(:status, 'proposed')
     end
   end
 
   def set_default_status
-    self.status ||= 'draft'
+    self.status ||= 'drafted'
   end
 
   def finisher
@@ -56,16 +80,60 @@ class Project < ApplicationRecord
     where({ status: 'proposed' })
   end
 
-  def self.approved
-    where({ status: 'approved' })
+  def self.submitted_via_google
+    where({ status: 'submitted via google' })
   end
 
-  def self.in_progress
-    where({ status: 'in progress' })
+  def self.project_confirm_email_sent
+    where({ status: 'project confirm email sent' })
+  end
+
+  def self.ready_to_match
+    where({ status: 'ready to match' })
+  end
+
+  def self.finisher_invited
+    where({ status: 'finisher invited' })
+  end
+
+  def self.project_accepted_waiting_on_terms
+    where({ status: 'project accepted/waiting on terms' })
+  end
+
+  def self.introduced
+    where({ status: 'introduced' })
+  end
+
+  def self.in_process
+    where({ status: 'in process' })
   end
 
   def self.finished
-    where({ status: 'finished' })
+    where({ status: 'finished/not returned' })
+  end
+
+  def self.done
+    where({ status: 'done' })
+  end
+
+  def self.unresponsive
+    where({ status: 'unresponsive' })
+  end
+
+  def self.on_hold
+    where({ status: 'on hold' })
+  end
+
+  def self.will_not_do
+    where({ status: 'will not do' })
+  end
+
+  def self.waiting_for_return_to_rematch
+    where({ status: 'waiting for return to rematch' })
+  end
+
+  def self.weird_circumstance
+    where({ status: 'weird circumstance' })
   end
 
   def self.has_status (status_state)

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -19,10 +19,8 @@
     .col-2
       = link_to 'Projects', manage_projects_path
     .col-2
-      Proposed: #{Project.proposed.count}
+      Proposed: #{Project.proposed.count + Project.submitted_via_google.count}
     .col-2
-      Approved: #{Project.approved.count}
+      In Progress: #{Project.on_hold.count + Project.project_confirm_email_sent.count + Project.ready_to_match.count + Project.finisher_invited.count + Project.project_accepted_waiting_on_terms.count + Project.introduced.count + Project.in_process.count + Project.will_not_do.count + Project.unresponsive.count + Project.waiting_for_return_to_rematch.count + Project.weird_circumstance.count}
     .col-2
-      In Progress: #{Project.in_progress.count}
-    .col-2
-      Finished: #{Project.finished.count}
+      Done: #{Project.done.count}

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -16,6 +16,10 @@
     .col-4
       = form.label :ready_status, 'Ready to Match Status', class: 'form-label'
       = form.select :ready_status, Project::READY_TO_MATCH_STATUSES.map { |status| [status.humanize, status] }, { include_blank: true }, { class: 'form-select' }
+  .row.mb-4#in-process-status-row{ style: (@project.status == 'in process' ? '' : 'display: none;') }
+    .col-4
+      = form.label :in_process_status, 'In Process Status', class: 'form-label'
+      = form.select :in_process_status, Project::IN_PROCESS_STATUSES.map { |status| [status.humanize, status] }, { include_blank: true }, { class: 'form-select' }
 
   .row.mb-4
     .col-6

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -6,10 +6,16 @@
       = form.text_field :name, class: 'form-control'
     .col-2
       = form.label :status, class: 'form-label'
-      = form.select :status, Project::STATUSES.map{ |status| [status.humanize, status ]}, { }, { class: 'form-select' }
+      = form.select :status, Project::STATUSES.map { |status| [status.humanize, status] }, { }, { id: 'status-dropdown', class: 'form-select' }
     .col-2
       = form.label :manager_id, class: 'form-label'
       = form.select :manager_id, User.project_managers.map { |a| [a.name, a.id] }, { include_blank: true }, { class: 'form-select' }
+    
+  -# This section will be toggled based on the selected status
+  .row.mb-4#ready-status-row{ style: (@project.status == 'ready to match' ? '' : 'display: none;') }
+    .col-4
+      = form.label :ready_status, 'Ready to Match Status', class: 'form-label'
+      = form.select :ready_status, Project::READY_TO_MATCH_STATUSES.map { |status| [status.humanize, status] }, { include_blank: true }, { class: 'form-select' }
 
   .row.mb-4
     .col-6

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -25,6 +25,10 @@
     .col-4
       = label_tag :ready_status, 'Ready to Match Status:', class: 'form-label'
       = select_tag :ready_status, options_for_select(Project::READY_TO_MATCH_STATUSES.map { |status| ["#{status.humanize}#{Project.has_ready_status(status).any? ? " (#{Project.has_ready_status(status).count})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
+  .row.mb-4#in-process-status-row{ style: "display: none;" }
+    .col-4
+      = label_tag :in_process_status, 'In Process Status:', class: 'form-label'
+      = select_tag :in_process_status, options_for_select(Project::IN_PROCESS_STATUSES.map { |status| ["#{status.humanize}#{Project.has_in_process_status(status).any? ? " (#{Project.has_in_process_status(status).count})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
 
 .row
   = render @projects

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -13,7 +13,7 @@
     .col
   .row.mb-4
     .col
-      = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status.humanize}#{Project.has_status(status).any? ? " (#{Project.has_status(status).count})" : ''}", status ]}, params[:status]), include_blank: true, class: 'form-select'
+      = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status.humanize}#{Project.has_status(status).any? ? " (#{Project.has_status(status).count})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
     .col
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
     .col
@@ -21,6 +21,10 @@
     .col
       = submit_tag "Search", name: nil, class: 'btn btn-primary'
 
+  .row.mb-4#ready-status-row{ style: "display: none;" }
+    .col-4
+      = label_tag :ready_status, 'Ready to Match Status:', class: 'form-label'
+      = select_tag :ready_status, options_for_select(Project::READY_TO_MATCH_STATUSES.map { |status| ["#{status.humanize}#{Project.has_ready_status(status).any? ? " (#{Project.has_ready_status(status).count})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
 
 .row
   = render @projects

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -3,6 +3,8 @@
   - if current_user.admin?
     - if @project.status == 'ready to match' && @project.ready_status.present?
       (#{@project.status.humanize} - #{@project.ready_status.humanize})
+    - elsif @project.status == 'in process' && @project.in_process_status.present?
+      (#{@project.status.humanize} - #{@project.in_process_status.humanize})
     - else
       (#{@project.status.humanize})
   - if current_user.can_manage? || current_user == @project.user

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -1,7 +1,10 @@
 %h1
   = @project.name
   - if current_user.admin?
-    (#{@project.status.humanize})
+    - if @project.status == 'ready to match' && @project.ready_status.present?
+      (#{@project.status.humanize} - #{@project.ready_status.humanize})
+    - else
+      (#{@project.status.humanize})
   - if current_user.can_manage? || current_user == @project.user
     = link_to 'Edit', [:edit, :manage, @project], class: 'btn btn-outline-secondary float-end'
 

--- a/db/migrate/20241103112120_add_ready_status_to_projects.rb
+++ b/db/migrate/20241103112120_add_ready_status_to_projects.rb
@@ -1,0 +1,5 @@
+class AddReadyStatusToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :ready_status, :string
+  end
+end

--- a/db/migrate/20241104104032_add_in_process_status_to_projects.rb
+++ b/db/migrate/20241104104032_add_in_process_status_to_projects.rb
@@ -1,0 +1,5 @@
+class AddInProcessStatusToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :in_process_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_03_112120) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_04_104032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -187,6 +187,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_03_112120) do
     t.float "longitude"
     t.bigint "manager_id"
     t.string "ready_status"
+    t.string "in_process_status"
     t.index ["latitude"], name: "index_projects_on_latitude"
     t.index ["longitude"], name: "index_projects_on_longitude"
     t.index ["manager_id"], name: "index_projects_on_manager_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_08_024446) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_03_112120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -186,6 +186,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_08_024446) do
     t.float "latitude"
     t.float "longitude"
     t.bigint "manager_id"
+    t.string "ready_status"
     t.index ["latitude"], name: "index_projects_on_latitude"
     t.index ["longitude"], name: "index_projects_on_longitude"
     t.index ["manager_id"], name: "index_projects_on_manager_id"


### PR DESCRIPTION
This PR adds all the newly-aligned project statuses to the web app. I elected to add the whole list of statuses as project statuses (rather than having some as assignee statuses) to mimic what is done in Google Sheets currently. This will make searching and the workflow in general more like the way it is currently done.

Both `Ready to Match` and `In Process` have five statuses of their own. These options are shown conditionally when `Ready to Match` or `In Process` is selected in the status dropdown. The new dropdowns have been added to the manage projects dashboard and the edit project page (I think those are the only two places they need to be).

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/54de5665-4196-422f-89dd-92aacfc1c34c">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1c0d42de-5503-4b7a-93ca-6912fc315114">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3db68d90-92cb-49e5-b5a4-723d17faf5a5">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/9c6f61eb-d865-499e-be79-174a981d1dbf">

[Screen Recording 2024-11-04 at 7.35.46 AM.mov.zip](https://github.com/user-attachments/files/17617234/Screen.Recording.2024-11-04.at.7.35.46.AM.mov.zip)
