### PR TITLE
Use regex to capitalize PO in project in process statuses

### DIFF
--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -19,7 +19,7 @@
   .row.mb-4#in-process-status-row{ style: (@project.status == 'in process' ? '' : 'display: none;') }
     .col-4
       = form.label :in_process_status, 'In Process Status', class: 'form-label'
-      = form.select :in_process_status, Project::IN_PROCESS_STATUSES.map { |status| [status.humanize, status] }, { include_blank: true }, { class: 'form-select' }
+      = form.select :in_process_status, Project::IN_PROCESS_STATUSES.map { |status| [status.humanize.gsub(/\bpo\b/i, 'PO'), status] }, { include_blank: true }, { class: 'form-select' }
 
   .row.mb-4
     .col-6

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -28,7 +28,7 @@
   .row.mb-4#in-process-status-row{ style: "display: none;" }
     .col-4
       = label_tag :in_process_status, 'In Process Status:', class: 'form-label'
-      = select_tag :in_process_status, options_for_select(Project::IN_PROCESS_STATUSES.map { |status| ["#{status.humanize}#{Project.has_in_process_status(status).any? ? " (#{Project.has_in_process_status(status).count})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
+      = select_tag :in_process_status, options_for_select(Project::IN_PROCESS_STATUSES.map { |status| ["#{status.humanize.gsub(/\bpo\b/i, 'PO')}#{Project.has_in_process_status(status).any? ? " (#{Project.has_in_process_status(status).count})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
 
 .row
   = render @projects

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -4,7 +4,7 @@
     - if @project.status == 'ready to match' && @project.ready_status.present?
       (#{@project.status.humanize} - #{@project.ready_status.humanize})
     - elsif @project.status == 'in process' && @project.in_process_status.present?
-      (#{@project.status.humanize} - #{@project.in_process_status.humanize})
+      (#{@project.status.humanize} - #{@project.in_process_status.humanize.gsub(/\bpo\b/i, 'PO')})
     - else
       (#{@project.status.humanize})
   - if current_user.can_manage? || current_user == @project.user


### PR DESCRIPTION
Updates the locations where we humanize the in process statuses to convert any instance of 'po' or 'Po' to 'PO'. It still saves in the DB as a lowercase string as it should.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/75f7485f-3079-4b77-9d01-d25c6385f52f">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c4b9528a-fa4a-4abf-91aa-b67ca77e2743">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/83ea05ff-69a3-4126-b8f3-e084a23882f5">
