### PR TITLE
Add migration to default new project statuses to drafted

### DIFF
--- a/db/migrate/20241111235510_set_new_default_project_status.rb
+++ b/db/migrate/20241111235510_set_new_default_project_status.rb
@@ -1,0 +1,5 @@
+class SetNewDefaultProjectStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :projects, :status, 'drafted'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_04_104032) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_11_235510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -156,7 +156,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_04_104032) do
 
   create_table "projects", force: :cascade do |t|
     t.bigint "user_id"
-    t.string "status", default: "draft", null: false
+    t.string "status", default: "drafted", null: false
     t.string "name", null: false
     t.text "description"
     t.string "street"


### PR DESCRIPTION
I just tried adding a new project after the recent changes to add the new project statuses to the app. With the change from 'draft' status to 'drafted' status, the default that gets set upon creating a new project was not updated. This PR adds the migration to change the default so new projects can successfully be created again.