### PR TITLE
Fix link to edit more in projects

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -128,6 +128,6 @@
         .col-9
           More
         .col-3
-          = link_to 'Edit', [:edit_crafter, @project], class: 'btn btn-link float-end btn-sm'
+          = link_to 'Edit', [:edit_basics, @project], class: 'btn btn-link float-end btn-sm'
     OK to talk about this publicly? #{@project.can_publicize ? fa_icon(:check) : 'No'}
 


### PR DESCRIPTION
When editing the `More` section in a new project, the user should be taken to the first page of the project submission flow (:edit_basics).

https://github.com/user-attachments/assets/5a95ba4d-765b-46cc-b6c4-d3780c44fd1b
