### PR TITLE
Make project attribute checkboxes searchable

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -40,6 +40,14 @@ class Manage::ProjectsController < Manage::ManageController
     if (params[:project_manager].present?)
       @projects = @projects.where(manager_id: params[:project_manager])
     end
+    
+    # Add filters for checkbox attributes
+    [:joann_helped, :urgent, :influencer, :group_project, :press, :privacy_needed].each do |attr|
+      if params[attr].present?
+        @projects = @projects.where(attr => params[attr] == 'true')
+      end
+    end
+    
     @projects = @projects.paginate(page: params[:page])
   end
 

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -11,6 +11,8 @@
     .col
       Manager:
     .col
+      Attributes:
+    .col
   .row.mb-4
     .col
       = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status.humanize}#{Project.has_status(status).any? ? " (#{Project.has_status(status).count})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
@@ -18,6 +20,25 @@
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
     .col
       = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
+    .col
+      .form-check.mb-2
+        = check_box_tag :joann_helped, 'true', params[:joann_helped] == 'true', class: 'form-check-input'
+        = label_tag :joann_helped, 'Joann Helped', class: 'form-check-label'
+      .form-check.mb-2
+        = check_box_tag :urgent, 'true', params[:urgent] == 'true', class: 'form-check-input'
+        = label_tag :urgent, 'Urgent', class: 'form-check-label'
+      .form-check.mb-2
+        = check_box_tag :influencer, 'true', params[:influencer] == 'true', class: 'form-check-input'
+        = label_tag :influencer, 'Influencer', class: 'form-check-label'
+      .form-check.mb-2
+        = check_box_tag :group_project, 'true', params[:group_project] == 'true', class: 'form-check-input'
+        = label_tag :group_project, 'Group Project', class: 'form-check-label'
+      .form-check.mb-2
+        = check_box_tag :press, 'true', params[:press] == 'true', class: 'form-check-input'
+        = label_tag :press, 'Press', class: 'form-check-label'
+      .form-check
+        = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
+        = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
     .col
       = submit_tag "Search", name: nil, class: 'btn btn-primary'
 


### PR DESCRIPTION
The new project attribute checkbox fields need to be searchable. This PR adds the ability to search for projects on the /manage/projects page according to whether any of the checkboxes are checked.

https://github.com/user-attachments/assets/6619e1c6-013d-4e30-b80c-0a59d5be2bca

