### PR TITLE
Update text about material and cigarette smoke for projects

### DIFF
--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -63,10 +63,10 @@
 
   .row
     .col-xl-8.col-md-10
-      .form-info Was there cigarette smoke in the home?
+      .form-info Has this project been exposed to cigarette smoke?
       = form.label 'has_smoke_in_home', class: 'form-label' do
         = form.check_box :has_smoke_in_home
-        Yes, there was cigarette smoke in the home.
+        Yes, this project has been exposed to cigarette smoke.
 
   .row.g-1.g-sm-4.mb-3
     .col-12
@@ -90,7 +90,7 @@
     .row.mb-2
       .col-6
         = form.label 'What kind of yarn / material is used?', class: 'form-label required'
-        .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc). Do you know?
+        .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc). If you do not know, say "I don't know."
         = form.text_field :material_type, class: 'form-control'
     .row.mb-2
       .col-4

--- a/app/views/projects/_crafter_form.html.haml
+++ b/app/views/projects/_crafter_form.html.haml
@@ -36,10 +36,10 @@
 
     .row
       .col-xl-8.col-md-10
-        .form-info Was there cigarette smoke in the home?
+        .form-info Has this project been exposed to cigarette smoke?
         = form.label 'has_smoke_in_home', class: 'form-label' do
           = form.check_box :has_smoke_in_home
-          Yes, there was cigarette smoke in the home.
+          Yes, this project has been exposed to cigarette smoke.
 
     .row.g-1.g-sm-4.mb-3
       .col-12

--- a/app/views/projects/_project_form.html.haml
+++ b/app/views/projects/_project_form.html.haml
@@ -6,7 +6,7 @@
     .row.mb-2
       .col-6
         = form.label 'What kind of yarn / material is used?', class: 'form-label required'
-        .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc). Do you know?
+        .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc). If you do not know, say "I don't know."
         = form.text_field :material_type, class: 'form-control'
     .row.mb-2
       .col-4
@@ -18,7 +18,7 @@
   .page-section
     %h5 Pattern
     .row.mb-2
-      .col-2
+      .col-4
         = form.label 'Is there a pattern', class: 'form-label required'
         = form.select :has_pattern, ['Yes', 'No', "I don't know"], { include_blank: true }, { class: 'form-select' }
     .row.mb-2


### PR DESCRIPTION
A couple of small copy fixes for the project submission form and manage projects. Updated the question about cigarette smoke in the home and type of project material. Also changed the column width for "Is there a pattern" so it no longer wraps onto a second line.

Slack list items:
* https://looseendsproject.slack.com/lists/T05GP1TRWQM/F079DEBF90W?record_id=Rec07H8A509RT
* https://looseendsproject.slack.com/lists/T05GP1TRWQM/F079DEBF90W?record_id=Rec07HB3S55AP

Material Details:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/acb3b2f7-8b87-4b03-803b-ed67e2ed3a50" />

Crafter Details:
<img width="438" alt="image" src="https://github.com/user-attachments/assets/76a33484-191c-4216-9809-66494e0a7d49" />

Is there a pattern column width:
<img width="418" alt="image" src="https://github.com/user-attachments/assets/705c67f7-91e6-4b8c-a075-1ba59709de69" />
