### PR TITLE
Make Projects unfinished text red and add periods

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -69,7 +69,7 @@
           = link_to 'Edit', [:edit_project, @project], class: 'btn btn-link float-end btn-sm'
     - if !@project.material_type.present? || @project.material_images.present?
       %p.text-danger
-        Tell us about the material
+        Tell us about the material.
 
     = @project.material_type
     - @project.material_images.each do |image|
@@ -83,7 +83,7 @@
 
     - if !@project.has_pattern.present?
       %p.text-danger
-        Tell us about the pattern
+        Tell us about the pattern.
     - else
       %p
         Is there a pattern? #{@project.has_pattern}
@@ -99,8 +99,8 @@
         .col-3
           = link_to 'Edit', [:edit_crafter, @project], class: 'btn btn-link float-end btn-sm'
     - if !@project.crafter_name.present? && (!@project.crafter_description.present? || !@project.crafter_images.present?)
-      %p
-        We'd love to know more about the crafter
+      %p.text-danger
+        We'd love to know more about the crafter.
     = @project.crafter_name
     = @project.crafter_description
     - @project.crafter_images.each do |image|


### PR DESCRIPTION
Updates the "unfinished" text on the projects show page.

Periods were added after:
* Tell us about the material
* Tell us about the pattern
* We'd love to know more about the crafter

And "We'd love to know more about the crafter" was given the text-danger class because there are required fields that need to be filled out.

Links to Slack list items:
* https://looseendsproject.slack.com/lists/T05GP1TRWQM/F079DEBF90W?record_id=Rec07HDLTPCDA
* https://looseendsproject.slack.com/lists/T05GP1TRWQM/F079DEBF90W?record_id=Rec07HB6JKGJW

Before:
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/27d7412c-5f4f-4679-a8cf-a1e37d50e695" />

After:
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/0fea7071-3e53-4d87-95a5-bea817071ae5" />
