### PR TITLE
Handle GET requests to /users

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
   get 'about-us', to: 'home#about-us'
 
+  get 'users', to: redirect('/users/sign_up')
+
   resources :projects, :except => :edit do
     member do
       get 'edit_basics'


### PR DESCRIPTION
Handle GET requests to /users by redirecting back to /users/sign_up. The site would respond "no route matches [GET] '/users'" if a user used the browser refresh _after_ submitting a sign up with invalid data. After this change, the user will be redirected back to the sign up page to continue.

See Also: [Slack list item](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F079DEBF90W?record_id=Rec08AXLAQMNH)