### PR TITLE
Set up regular db backups in prod

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# .env
+
+# RAILS_DISPLAY_ENV is to visually differentiate the staging and production
+# environments.  For acceptance testing, it is recommended to set RAILS_ENV
+# to "production" just like real production.  So we do this...
+RAILS_DISPLAY_ENV="development"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 .DS_Store
 */.DS_Store
+latest.dump
 
 # Ignore bundler config.
 /.bundle


### PR DESCRIPTION
See https://devcenter.heroku.com/articles/heroku-postgres-backups#check-backup-status-and-info

1.  Changed .gitignore to ignore `latest.dump` in case you have one in your dev env
2. Issued `heroku pg:backups:schedule` on prod to back up daily at 2am America/New_York
3. Restored `latest.dump` to my dev db.  Works nice