### PR TITLE
capture pgdump from prod periodically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 
 /public/assets
 
+/db/backups/*
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 


### PR DESCRIPTION
1. Did `heroku pg:backups:schedule` for 2am daily America/New_York.  Seven day retention
2. Downloaded manual backup and restored to dev db
3. Updated .gitignore so backups won't get committed (as long as you put them in /db/backups)