### PR TITLE
Make inputs on sign up screen reader accessible

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -10,10 +10,10 @@
 
   .row.g-1.g-sm-4
     .col-6.col-sm-5.col-md-4
-      = f.label 'First Name', class: 'col-form-label required'
+      = f.label :first_name,  'First Name', class: 'col-form-label required'
       = f.text_field :first_name, autofocus: true, autocomplete: "given-name", class: 'form-control'
     .col-6.col-sm-5.col-md-4
-      = f.label 'Last name', class: 'col-form-label required'
+      = f.label :last_name, 'Last name', class: 'col-form-label required'
       = f.text_field :last_name, autocomplete: "family-name", class: 'form-control'
   .row.g-1.g-sm-4
     .col-12.col-sm-10.col-md-8


### PR DESCRIPTION
While testing #50, I realized a couple other of our form inputs weren't screen reader accessible. It's a quick fix, so I wanted to get it up.

Added the specific attribute to the FormBuilder's label method so the input is correctly labeled for screen readers.

[Docs about FormBuilder and the label method](https://api.rubyonrails.org/v8.0.1/classes/ActionView/Helpers/FormBuilder.html#method-i-label)