### PR TITLE
Remove project_id requirements for finisher autocomplete.

### DIFF
--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -137,7 +137,7 @@
         .row.mb-3#group-manager-row{ style: (@project.group_project ? '' : 'display: none;') }
           .col-6
             = form.label :group_manager_id, 'Group Manager', class: 'form-label'
-            .autocomplete#group-manager-autocomplete{ data: { controller: 'autocomplete', autocomplete_url: search_manage_project_finishers_path(@project) } }
+            .autocomplete#group-manager-autocomplete{ data: { controller: 'autocomplete', autocomplete_url: finishers_search_manage_projects_path() } }
               = text_field_tag :group_manager_name, @project.group_manager&.name, class: 'form-control', data: { autocomplete_target: 'input', action: 'input->autocomplete#fetch' }
               = form.hidden_field :group_manager_id, value: @project.group_manager_id, data: { autocomplete_target: 'hidden' }
         .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,11 @@ Rails.application.routes.draw do
       resources :finishers, :only => [:index] do
         collection do
           get 'map'
-          get :search, to: 'finishers#search'
         end
         get 'card', on: :member
+      end
+      collection do
+        get 'finishers/search', to: 'finishers#search'
       end
     end
     resources :finishers do


### PR DESCRIPTION
This change moves the search action from /manage/projects/:project_id/finishers/search(.:format) to /manage/projects/finishers/search(.:format) as the :project_id was not used in the search action.

The finisher autocomplete route was set to require a :project_id. When creating a new project the path method was being called with a valid Project object, but one which had no id (from Project.new). This caused the path method to raise an error because it was trying to use the id of the Project object as the :project_id parameter. Since the project id was not used by the search it seemed easiest to remove the requirement for the :project_id parameter.

It's not totally clear to me how #48 uncovered this as it was focused on moving the existing HAML structure around and should not have changed it. Since this is blocking some functionality it felt better to fix via simplification than keep chasing my tail on this specific point. I'll research how it worked in development at the start of next week so I can be sure it won't happen again.