### PR TITLE
Add tests for manage finishers and projects controllers

### DIFF
--- a/app/controllers/manage/finishers_controller.rb
+++ b/app/controllers/manage/finishers_controller.rb
@@ -71,12 +71,16 @@ class Manage::FinishersController < Manage::ManageController
   end
 
   def search
+    if params[:term].blank?
+      return render json: []
+    end
+
     # Fetch finishers matching the search term (case insensitive)
     finishers = Finisher
                   .where('chosen_name ILIKE ?', "%#{params[:term]}%")
                   .limit(20)
                   .select(:id, :chosen_name)
-  
+
     render json: finishers.map { |f| { id: f.id, name: f.chosen_name } }
   end
 

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -40,14 +40,14 @@ class Manage::ProjectsController < Manage::ManageController
     if (params[:project_manager].present?)
       @projects = @projects.where(manager_id: params[:project_manager])
     end
-    
+
     # Add filters for checkbox attributes
     [:joann_helped, :urgent, :influencer, :group_project, :press, :privacy_needed].each do |attr|
       if params[attr].present?
         @projects = @projects.where(attr => params[attr] == 'true')
       end
     end
-    
+
     @projects = @projects.paginate(page: params[:page])
   end
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,6 +7,5 @@ Geocoder.configure(
   use_https: true,
 
   # geocoding service request timeout, in seconds (default 3):
-  timeout: 5,
-
-  )
+  timeout: 5
+)

--- a/test/controllers/manage/finishers_controller_test.rb
+++ b/test/controllers/manage/finishers_controller_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class Manage::FinishersControllerTest < ActionController::TestCase
+  setup do
+    @user = users(:anne)
+    assert(@user.can_manage?)
+  end
+
+  test 'search requires login' do
+    get :search
+    assert_redirected_to new_user_registration_path
+  end
+
+  test 'search requires can_manage? access' do
+    @user_without_manager = users(:bob)
+    refute(@user_without_manager.can_manage?)
+
+    sign_in @user_without_manager
+    get :search
+    assert_redirected_to root_path
+  end
+
+  test 'search with no parameters' do
+    sign_in @user
+    get :search
+    assert_response :success
+    assert_equal([], JSON.parse(response.body))
+  end
+
+  test 'search with no matches' do
+    sign_in @user
+    get :search, params: { term: 'xyz' }
+    assert_response :success
+    assert_equal([], JSON.parse(response.body))
+  end
+
+  test 'search with parameters returning one match' do
+    sign_in @user
+    get :search, params: { term: 'fish' }
+    assert_response :success
+    assert_equal([{"id"=>2, "name"=>"Fran Fishman"}], JSON.parse(response.body))
+  end
+
+  test 'search with parameters returning multiple matches' do
+    sign_in @user
+    get :search, params: { term: 'f' }
+    assert_response :success
+    assert_equal([{"id"=>1, "name"=>"Fae Fenwick"}, {"id"=>2, "name"=>"Fran Fishman"}], JSON.parse(response.body))
+  end
+
+  test 'does not allow SQL injection' do
+    sign_in @user
+    get :search, params: { term: 'f;\' DROP TABLE finishers; --' }
+    assert_response :success
+    assert_equal([], JSON.parse(response.body))
+    assert(Finisher.count > 0)
+  end
+end

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class Manage::ProjectsControllerTest < ActionController::TestCase
+  setup do
+    @user = users(:anne)
+    assert(@user.can_manage?)
+    @project = projects(:one)
+  end
+
+  test 'index requires login' do
+    get :index
+    assert_redirected_to new_user_registration_path
+  end
+
+  test 'index requires can_manage? access' do
+    @user_without_manager = users(:bob)
+    refute(@user_without_manager.can_manage?)
+
+    sign_in @user_without_manager
+    get :index
+    assert_redirected_to root_path
+  end
+
+  test 'index loads' do
+    sign_in @user
+    get :index
+    assert_response :success
+  end
+
+  test 'new project page loads' do
+    sign_in @user
+    get :new
+    assert_response :success
+  end
+
+  test 'show loads' do
+    sign_in @user
+    get :show, params: { id: @project.id }
+    assert_response :success
+  end
+
+  test 'edit loads' do
+    sign_in @user
+    get :edit, params: { id: @project.id }
+    assert_response :success
+  end
+
+  test 'update alters project' do
+    @project.name = 'New Name'
+
+    sign_in @user
+    patch :update, params: { id: @project.id, project: { name: 'New Name' } }
+    assert_redirected_to manage_project_path(@project)
+    assert_equal('New Name', @project.reload.name)
+  end
+
+  test 'create with incomplete params renders page' do
+    sign_in @user
+    get :create, params: { project: { name: 'Lacking Details' } }
+    assert_response :success
+  end
+
+  test 'create with complete params creates project' do
+    project_params = new_project_params
+    sign_in @user
+    assert_difference('Project.count') do
+      post :create, params: { project: project_params }
+    end
+    assert_redirected_to manage_project_path(Project.last)
+  end
+
+  private
+
+  def new_project_params
+    project_params = @project.attributes.dup
+    %w(id user_id created_at updated_at latitude longitude country).each do |key|
+      project_params.delete(key)
+    end
+    project_params['name'] = 'New Project Name'
+    project_params['append_project_images'] = [fixture_file_upload('test.jpg')]
+    project_params
+  end
+end

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -69,6 +69,15 @@ class Manage::ProjectsControllerTest < ActionController::TestCase
     assert_redirected_to manage_project_path(Project.last)
   end
 
+  test 'destroy removes project' do
+    sign_in @user
+    assert_difference('Project.count', -1) do
+      delete :destroy, params: { id: @project.id }
+    end
+    assert_redirected_to manage_projects_path
+    refute(Project.exists?(@project.id))
+  end
+
   private
 
   def new_project_params

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,19 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  Geocoder.configure(:lookup => :test)
+  # Locations form test fixtures
+  Geocoder::Lookup::Test.add_stub(
+    "123 Main St, , Anytown, WA, 12345", [    {
+      'latitude'     => 40.7143528,
+      'longitude'    => -74.0059731,
+      'address'      => 'New York, NY, USA',
+      'state'        => 'New York',
+      'state_code'   => 'NY',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }]
+  )
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
Add some smoke tests for the project manage controller actions. This would have caught the bug in https://github.com/looseendsproject/webapp/pull/56. In a related move I added tests around the search endpoint autocomplete uses.

The new `search` action tests uncovered an issue where a request with no parameters would return all finishers. The current HTML form only makes requests with three or more characters so this would be an unexpected state. Rather than ignore it I felt like it was better to explicitly handle the case.