### PR TITLE
Fix a few automated test issues

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -37,5 +37,11 @@ PostCheckout:
     enabled: true
 
 PrePush:
+  ALL:
+    env:
+      # MacOS hangs due to odd fork/exec behavior
+      OBJC_DISABLE_INITIALIZE_FORK_SAFETY: "ON"
+  Minitest:
+    enabled: true
   RSpec:
     enabled: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,24 +3,21 @@ require_relative "../config/environment"
 require "rails/test_help"
 
 class ActiveSupport::TestCase
-  # Run tests in parallel with specified workers
-  parallelize(workers: :number_of_processors)
-
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-  Geocoder.configure(:lookup => :test)
+  Geocoder.configure(lookup: :test)
   # Locations form test fixtures
   Geocoder::Lookup::Test.add_stub(
-    "123 Main St, , Anytown, WA, 12345", [    {
-      'latitude'     => 40.7143528,
-      'longitude'    => -74.0059731,
-      'address'      => 'New York, NY, USA',
-      'state'        => 'New York',
-      'state_code'   => 'NY',
-      'country'      => 'United States',
-      'country_code' => 'US'
+    "123 Main St, , Anytown, WA, 12345", [{
+      "latitude" => 40.7143528,
+      "longitude" => -74.0059731,
+      "address" => "New York, NY, USA",
+      "state" => "New York",
+      "state_code" => "NY",
+      "country" => "United States",
+      "country_code" => "US"
     }]
   )
 end


### PR DESCRIPTION
There have been a few issues with warnings or hanging while running tests. Overcommit also had errors as it assumed RSpec by default. This branch:

  * Turns on `minitest` in Overcommit `PrePush`
    * Add the `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=ON` env to Overcommit, too
  * Removes the test parallelization that creates flakey Rails tests (we don't have that many tests)
    * Note: One of the tools also reformatted a stub but there is no substantive change 