### PR TITLE
Add ability to filter projects by last updated

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -45,8 +45,8 @@ module Manage
         @projects = @projects.where(attr => params[attr] == "true") if params[attr].present?
       end
 
-      @projects = @projects.where("updated_at >= ?", params[:updated_after]) if params[:updated_after].present?
-      @projects = @projects.where("updated_at <= ?", params[:updated_before]) if params[:updated_before].present?
+      @projects = @projects.where(updated_at: (params[:updated_after])..) if params[:updated_after].present?
+      @projects = @projects.where(updated_at: ..(params[:updated_before])) if params[:updated_before].present?
 
       @projects = @projects.paginate(page: params[:page])
     end

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -45,9 +45,18 @@ module Manage
         @projects = @projects.where(attr => params[attr] == "true") if params[attr].present?
       end
 
-      @projects = @projects.where(updated_at: (params[:updated_after])..) if params[:updated_after].present?
-      @projects = @projects.where(updated_at: ..(params[:updated_before])) if params[:updated_before].present?
+      updated_after = params[:updated_after]
+      updated_before = params[:updated_before]
+      # when both are present, make sure we're comparing the earliest date as the 'from' date
+      # and the latest date as the 'to' date (in case of user error)
+      if updated_after.present? && updated_before.present?
+        updated_after = [updated_after, updated_before].compact.min
+        updated_before = [updated_after, updated_before].compact.max
+      end
 
+      if updated_after.present? || updated_before.present?
+        @projects = @projects.where(updated_at: updated_after..updated_before)
+      end
       @projects = @projects.paginate(page: params[:page])
     end
 

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -45,6 +45,9 @@ module Manage
         @projects = @projects.where(attr => params[attr] == "true") if params[attr].present?
       end
 
+      @projects = @projects.where("updated_at >= ?", params[:updated_after]) if params[:updated_after].present?
+      @projects = @projects.where("updated_at <= ?", params[:updated_before]) if params[:updated_before].present?
+
       @projects = @projects.paginate(page: params[:page])
     end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -20,7 +20,7 @@
 #  index_assignments_on_user_id      (user_id)
 #
 class Assignment < ApplicationRecord
-  belongs_to :project
+  belongs_to :project, touch: true
   belongs_to :finisher
   belongs_to :user
 

--- a/app/models/project_note.rb
+++ b/app/models/project_note.rb
@@ -17,6 +17,6 @@
 #  index_project_notes_on_user_id     (user_id)
 #
 class ProjectNote < ApplicationRecord
-  belongs_to :project
+  belongs_to :project, touch: true
   belongs_to :user
 end

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -3,45 +3,42 @@
   = link_to 'New Project', [:new, :manage, :project], class: 'btn btn-outline-secondary float-end'
 
 = form_tag [:manage, :projects ], :method => :get do
-  .row
-    .col
-      = label_tag "status-dropdown", "Status:"
-    .col
-      = label_tag :assigned, "Assigned:"
-    .col
-      = label_tag :project_manager, "Manager:"
-    .col
-      = label_tag :attributes, "Attributes:"
-    .col
   .row.mb-4
     .col
+      = label_tag "status-dropdown", "Status:"
       = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status.humanize}#{Project.has_status(status).any? ? " (#{Project.has_status(status).count})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
     .col
+      = label_tag :assigned, "Assigned:"
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
     .col
+      = label_tag :project_manager, "Manager:"
       = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
+  .row.mb-4
     .col
-      %fieldset#attributes
-        .form-check.mb-2
-          = check_box_tag :joann_helped, 'true', params[:joann_helped] == 'true', class: 'form-check-input'
-          = label_tag :joann_helped, 'Joann Helped', class: 'form-check-label'
-        .form-check.mb-2
-          = check_box_tag :urgent, 'true', params[:urgent] == 'true', class: 'form-check-input'
-          = label_tag :urgent, 'Urgent', class: 'form-check-label'
-        .form-check.mb-2
-          = check_box_tag :influencer, 'true', params[:influencer] == 'true', class: 'form-check-input'
-          = label_tag :influencer, 'Influencer', class: 'form-check-label'
-        .form-check.mb-2
-          = check_box_tag :group_project, 'true', params[:group_project] == 'true', class: 'form-check-input'
-          = label_tag :group_project, 'Group Project', class: 'form-check-label'
-        .form-check.mb-2
-          = check_box_tag :press, 'true', params[:press] == 'true', class: 'form-check-input'
-          = label_tag :press, 'Press', class: 'form-check-label'
-        .form-check
-          = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
-          = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
-    .col
-      = submit_tag "Search", name: nil, class: 'btn btn-primary'
+      = label_tag :attributes, "Attributes:"
+      .row
+        .col
+          .form-check.mb-2
+            = check_box_tag :joann_helped, 'true', params[:joann_helped] == 'true', class: 'form-check-input'
+            = label_tag :joann_helped, 'Joann Helped', class: 'form-check-label'
+          .form-check.mb-2
+            = check_box_tag :urgent, 'true', params[:urgent] == 'true', class: 'form-check-input'
+            = label_tag :urgent, 'Urgent', class: 'form-check-label'
+          .form-check.mb-2
+            = check_box_tag :influencer, 'true', params[:influencer] == 'true', class: 'form-check-input'
+            = label_tag :influencer, 'Influencer', class: 'form-check-label'
+        .col
+          .form-check.mb-2
+            = check_box_tag :group_project, 'true', params[:group_project] == 'true', class: 'form-check-input'
+            = label_tag :group_project, 'Group Project', class: 'form-check-label'
+          .form-check.mb-2
+            = check_box_tag :press, 'true', params[:press] == 'true', class: 'form-check-input'
+            = label_tag :press, 'Press', class: 'form-check-label'
+          .form-check
+            = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
+            = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
+  .d-flex.mb-4.justify-content-center
+    = submit_tag "Search", name: nil, class: 'btn btn-primary'
 
   .row.mb-4#ready-status-row{ style: "display: none;" }
     .col-4

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -15,6 +15,12 @@
       = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
   .row.mb-4
     .col
+      = label_tag :updated_after, "Updated After:"
+      = date_field_tag :updated_after, params[:updated_after], class: 'form-control'
+    .col
+      = label_tag :updated_before, "Updated Before:"
+      = date_field_tag :updated_before, params[:updated_before], class: 'form-control'
+    .col
       = label_tag :attributes, "Attributes:"
       .row
         .col

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -5,13 +5,13 @@
 = form_tag [:manage, :projects ], :method => :get do
   .row
     .col
-      Status:
+      = label_tag "status-dropdown", "Status:"
     .col
-      Assigned:
+      = label_tag :assigned, "Assigned:"
     .col
-      Manager:
+      = label_tag :project_manager, "Manager:"
     .col
-      Attributes:
+      = label_tag :attributes, "Attributes:"
     .col
   .row.mb-4
     .col
@@ -21,24 +21,25 @@
     .col
       = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
     .col
-      .form-check.mb-2
-        = check_box_tag :joann_helped, 'true', params[:joann_helped] == 'true', class: 'form-check-input'
-        = label_tag :joann_helped, 'Joann Helped', class: 'form-check-label'
-      .form-check.mb-2
-        = check_box_tag :urgent, 'true', params[:urgent] == 'true', class: 'form-check-input'
-        = label_tag :urgent, 'Urgent', class: 'form-check-label'
-      .form-check.mb-2
-        = check_box_tag :influencer, 'true', params[:influencer] == 'true', class: 'form-check-input'
-        = label_tag :influencer, 'Influencer', class: 'form-check-label'
-      .form-check.mb-2
-        = check_box_tag :group_project, 'true', params[:group_project] == 'true', class: 'form-check-input'
-        = label_tag :group_project, 'Group Project', class: 'form-check-label'
-      .form-check.mb-2
-        = check_box_tag :press, 'true', params[:press] == 'true', class: 'form-check-input'
-        = label_tag :press, 'Press', class: 'form-check-label'
-      .form-check
-        = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
-        = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
+      %fieldset#attributes
+        .form-check.mb-2
+          = check_box_tag :joann_helped, 'true', params[:joann_helped] == 'true', class: 'form-check-input'
+          = label_tag :joann_helped, 'Joann Helped', class: 'form-check-label'
+        .form-check.mb-2
+          = check_box_tag :urgent, 'true', params[:urgent] == 'true', class: 'form-check-input'
+          = label_tag :urgent, 'Urgent', class: 'form-check-label'
+        .form-check.mb-2
+          = check_box_tag :influencer, 'true', params[:influencer] == 'true', class: 'form-check-input'
+          = label_tag :influencer, 'Influencer', class: 'form-check-label'
+        .form-check.mb-2
+          = check_box_tag :group_project, 'true', params[:group_project] == 'true', class: 'form-check-input'
+          = label_tag :group_project, 'Group Project', class: 'form-check-label'
+        .form-check.mb-2
+          = check_box_tag :press, 'true', params[:press] == 'true', class: 'form-check-input'
+          = label_tag :press, 'Press', class: 'form-check-label'
+        .form-check
+          = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
+          = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
     .col
       = submit_tag "Search", name: nil, class: 'btn btn-primary'
 

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -14,12 +14,13 @@
       = label_tag :project_manager, "Manager:"
       = select_tag :project_manager, options_for_select(User.project_managers.map { |a| [a.name, a.id] }, params[:project_manager]), include_blank: true, class: 'form-select'
   .row.mb-4
-    .col
-      = label_tag :updated_after, "Updated After:"
-      = date_field_tag :updated_after, params[:updated_after], class: 'form-control'
-    .col
-      = label_tag :updated_before, "Updated Before:"
-      = date_field_tag :updated_before, params[:updated_before], class: 'form-control'
+    .col.d-inline-flex
+      .d-flex.flex-column.me-2.w-50
+        = label_tag :updated_after, "Updated After:"
+        = date_field_tag :updated_after, params[:updated_after], class: 'form-control'
+      .d-flex.flex-column.ms-2.w-50
+        = label_tag :updated_before, "Updated Before:"
+        = date_field_tag :updated_before, params[:updated_before], class: 'form-control'
     .col
       = label_tag :attributes, "Attributes:"
       .row
@@ -43,8 +44,8 @@
           .form-check
             = check_box_tag :privacy_needed, 'true', params[:privacy_needed] == 'true', class: 'form-check-input'
             = label_tag :privacy_needed, 'Privacy Needed', class: 'form-check-label'
-  .d-flex.mb-4.justify-content-center
-    = submit_tag "Search", name: nil, class: 'btn btn-primary'
+    .col
+      = submit_tag "Search", name: nil, class: 'btn btn-primary'
 
   .row.mb-4#ready-status-row{ style: "display: none;" }
     .col-4

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -1,3 +1,5 @@
+= hidden_field_tag "updated_at_utc", @project.updated_at.iso8601
+%small#updated_at= "Last updated:"
 %h1
   = @project.name
   - if current_user.admin?
@@ -156,3 +158,15 @@
     #project_note_form
       = render partial: 'manage/project_notes/form', locals: { project: @project}
 
+:javascript
+  var updateProjectTimestamp = () => {
+    const timestamp = document.getElementById('updated_at_utc');
+    const date = new Date(timestamp.value).toLocaleDateString()
+    const time = new Date(timestamp.value).toLocaleTimeString()
+
+    const text = document.getElementById('updated_at')
+    text.innerHTML = `Last updated: ${date} ${time}`
+  }
+
+  window.addEventListener('load', updateProjectTimestamp);
+  document.addEventListener('turbo:load', updateProjectTimestamp);

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -35,6 +35,17 @@ module Manage
       assert_response :success
     end
 
+    test "index filters by updated_at" do
+      sign_in @user
+      get :index, params: { updated_after: @project.updated_at.to_date }
+      assert_response :success
+      assert_select "h6", { text: @project.name, count: 1 }
+
+      get :index, params: { updated_before: @project.updated_at.to_date - 1.day }
+      assert_response :success
+      assert_select "h6", { text: @project.name, count: 0 }
+    end
+
     test "new project page loads" do
       sign_in @user
       get :new

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -12,7 +12,7 @@ module Manage
     end
 
     test "index requires login" do
-      get :index
+      get "/manage/projects"
 
       assert_redirected_to new_user_registration_path
     end
@@ -23,26 +23,26 @@ module Manage
       assert_not_predicate(@user_without_manager, :can_manage?)
 
       sign_in @user_without_manager
-      get :index
+      get "/manage/projects"
 
       assert_redirected_to root_path
     end
 
     test "index loads" do
       sign_in @user
-      get :index
+      get "/manage/projects"
 
       assert_response :success
     end
 
     test "index filters by updated_at" do
       sign_in @user
-      get :index, params: { updated_after: @project.updated_at.to_date }
+      get "/manage/projects", params: { updated_after: @project.updated_at.to_date }
 
       assert_response :success
       assert_select "h6", { text: @project.name, count: 1 }
 
-      get :index, params: { updated_before: @project.updated_at.to_date - 1.day }
+      get "/manage/projects", params: { updated_before: @project.updated_at.to_date - 1.day }
 
       assert_response :success
       assert_select "h6", { text: @project.name, count: 0 }
@@ -50,21 +50,21 @@ module Manage
 
     test "new project page loads" do
       sign_in @user
-      get :new
+      get "/manage/projects/new"
 
       assert_response :success
     end
 
     test "show loads" do
       sign_in @user
-      get :show, params: { id: @project.id }
+      get "/manage/projects/#{@project.id}"
 
       assert_response :success
     end
 
     test "edit loads" do
       sign_in @user
-      get :edit, params: { id: @project.id }
+      get "/manage/projects/#{@project.id}/edit"
 
       assert_response :success
     end
@@ -73,7 +73,7 @@ module Manage
       @project.name = "New Name"
 
       sign_in @user
-      patch :update, params: { id: @project.id, project: { name: "New Name" } }
+      patch "/manage/projects/#{@project.id}", params: { project: { name: "New Name" } }
 
       assert_redirected_to manage_project_path(@project)
       assert_equal("New Name", @project.reload.name)
@@ -81,7 +81,7 @@ module Manage
 
     test "create with incomplete params renders page" do
       sign_in @user
-      get :create, params: { project: { name: "Lacking Details" } }
+      post "/manage/projects", params: { project: { name: "Lacking Details" } }
 
       assert_response :success
     end
@@ -90,7 +90,7 @@ module Manage
       project_params = new_project_params
       sign_in @user
       assert_difference("Project.count") do
-        post :create, params: { project: project_params }
+        post "/manage/projects", params: { project: project_params }
       end
       assert_redirected_to manage_project_path(Project.last)
     end
@@ -98,7 +98,7 @@ module Manage
     test "destroy removes project" do
       sign_in @user
       assert_difference("Project.count", -1) do
-        delete :destroy, params: { id: @project.id }
+        delete "/manage/projects/#{@project.id}"
       end
       assert_redirected_to manage_projects_path
       assert_not(Project.exists?(@project.id))

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 module Manage
-  class ProjectsControllerTest < ActionController::TestCase
+  class ProjectsControllerTest < ActionDispatch::IntegrationTest
     setup do
       @user = users(:admin)
 
@@ -38,10 +38,12 @@ module Manage
     test "index filters by updated_at" do
       sign_in @user
       get :index, params: { updated_after: @project.updated_at.to_date }
+
       assert_response :success
       assert_select "h6", { text: @project.name, count: 1 }
 
       get :index, params: { updated_before: @project.updated_at.to_date - 1.day }
+
       assert_response :success
       assert_select "h6", { text: @project.name, count: 0 }
     end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -76,6 +76,7 @@ one:
   state: WA
   postal_code: 12345
   country: USA
+  updated_at: <%= 7.days.ago %>
 
 two:
   id: 2
@@ -85,3 +86,4 @@ two:
   status: ready to match
   phone_number: 1234567890
   craft_type: knitting
+  updated_at: <%= 2.days.ago %>

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -140,26 +140,30 @@ class ProjectTest < ActiveSupport::TestCase
   test "updated_at timestamp updated when a project note is added" do
     original_updated_at = @project.updated_at
     @project.project_notes.create(user: User.new, description: "here's a new note")
-    refute_equal(original_updated_at, @project.updated_at)
+
+    assert_not_equal(original_updated_at, @project.updated_at)
   end
 
   test "updated_at timestamp updated when a project note is updated" do
     note = @project.project_notes.create(user: User.new, description: "here's a new note")
     original_updated_at = @project.updated_at
     note.update(description: "updated note description")
-    refute_equal(original_updated_at, @project.updated_at)
+
+    assert_not_equal(original_updated_at, @project.updated_at)
   end
 
   test "updated_at timestamp updated when an assignment is added" do
     original_updated_at = @project.updated_at
     @project.assignments.create(user: User.new, finisher: finishers(:crocheter))
-    refute_equal(original_updated_at, @project.updated_at)
+
+    assert_not_equal(original_updated_at, @project.updated_at)
   end
 
   test "updated_at timestamp updated when an assignment is updated" do
     assignment = @project.assignments.create(user: User.new, finisher: finishers(:crocheter))
     original_updated_at = @project.updated_at
     assignment.update(started_at: DateTime.now)
-    refute_equal(original_updated_at, @project.updated_at)
+
+    assert_not_equal(original_updated_at, @project.updated_at)
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -136,4 +136,30 @@ class ProjectTest < ActiveSupport::TestCase
       assert_predicate(@project, :missing_information?, "Project should be missing information when #{field} is nil")
     end
   end
+
+  test "updated_at timestamp updated when a project note is added" do
+    original_updated_at = @project.updated_at
+    @project.project_notes.create(user: User.new, description: "here's a new note")
+    refute_equal(original_updated_at, @project.updated_at)
+  end
+
+  test "updated_at timestamp updated when a project note is updated" do
+    note = @project.project_notes.create(user: User.new, description: "here's a new note")
+    original_updated_at = @project.updated_at
+    note.update(description: "updated note description")
+    refute_equal(original_updated_at, @project.updated_at)
+  end
+
+  test "updated_at timestamp updated when an assignment is added" do
+    original_updated_at = @project.updated_at
+    @project.assignments.create(user: User.new, finisher: finishers(:crocheter))
+    refute_equal(original_updated_at, @project.updated_at)
+  end
+
+  test "updated_at timestamp updated when an assignment is updated" do
+    assignment = @project.assignments.create(user: User.new, finisher: finishers(:crocheter))
+    original_updated_at = @project.updated_at
+    assignment.update(started_at: DateTime.now)
+    refute_equal(original_updated_at, @project.updated_at)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,3 +31,9 @@ module ActionController
     include Devise::Test::ControllerHelpers
   end
 end
+
+module ActionDispatch
+  class IntegrationTest
+    include Devise::Test::IntegrationHelpers
+  end
+end


### PR DESCRIPTION
## Requirements
Each Project should have a date field labeled 'Last update'. Any time something changes within the project, the date should automatically update.

When using search, the date field should be able to be used for searching and sorting. I.e. the user should be able to search for projects with a last update that falls in a date range (e.g. before November 1st) and should be able to sort any search results by date of last update.

## Changes
- add `touch: true` to both `project_notes` and `assignments` so when either of those associations get changed in any way, the parent project's `updated_at` timestamp is updated. `updated_at` will still be updated if the project itself has any changes too
- update the project search/filter page to be able to filter by `updated_at`. I moved things around a little bit to make some more room for these new inputs
- display the `updated_at` timestamp on the project detail page in the user's time zone (from the browser)


(screenshots from my local env)
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/b743dd5f-5b5a-44a6-af4d-784196fbb124" />


<img width="1014" alt="image" src="https://github.com/user-attachments/assets/46ff12cf-3213-4573-b76a-1ce1511c6a02" />
