### PR TITLE
Enable Devise :confirmable, but do not restrict login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :validatable, :trackable
 
   validates :role, inclusion: { in: ROLES }
@@ -64,5 +64,13 @@ class User < ApplicationRecord
 
   def finisher?
     !!finisher
+  end
+
+  protected
+
+  # Allow users with unconfirmed emails to log in.  (Just don't send transactional
+  # emails until they're confirmed.)
+  def confirmation_required?
+    false
   end
 end

--- a/db/migrate/20250212195851_add_confirmable_to_devise.rb
+++ b/db/migrate/20250212195851_add_confirmable_to_devise.rb
@@ -1,0 +1,16 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
+
+  # see https://github.com/heartcombo/devise/wiki/How-To:-Add-:confirmable-to-Users
+
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_index :users, :confirmation_token, unique: true
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_12_195851) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,7 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.bigint "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index %w[record_type record_id name], name: "index_action_text_rich_texts_uniqueness", unique: true
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -33,8 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index %w[record_type record_id name blob_id], name: "index_active_storage_attachments_uniqueness",
-                                                    unique: true
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -52,7 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index %w[blob_id variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "agencies", id: :serial, force: :cascade do |t|
@@ -361,7 +358,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.string "queue", limit: 255
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.index %w[priority run_at], name: "delayed_jobs_priority"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "ebp_documents", id: :serial, force: :cascade do |t|
@@ -542,7 +539,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.string "lon", limit: 255
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.index %w[lat lon], name: "index_locations_on_lat_and_lon"
+    t.index ["lat", "lon"], name: "index_locations_on_lat_and_lon"
   end
 
   create_table "lookups", id: :serial, force: :cascade do |t|
@@ -553,7 +550,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["code"], name: "index_lookups_on_code"
-    t.index %w[type code], name: "index_lookups_on_type_and_code"
+    t.index ["type", "code"], name: "index_lookups_on_type_and_code"
   end
 
   create_table "measure_question_answers", id: :serial, force: :cascade do |t|
@@ -655,7 +652,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.text "body"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.index %w[targetable_id targetable_type], name: "index_messages_on_targetable_id_and_targetable_type"
+    t.index ["targetable_id", "targetable_type"], name: "index_messages_on_targetable_id_and_targetable_type"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
@@ -677,7 +674,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["code"], name: "index_organization_lookups_on_code"
-    t.index %w[type code], name: "index_organization_lookups_on_type_and_code"
+    t.index ["type", "code"], name: "index_organization_lookups_on_type_and_code"
   end
 
   create_table "organization_measures", id: :serial, force: :cascade do |t|
@@ -1146,6 +1143,10 @@ ActiveRecord::Schema[7.0].define(version: 20_250_203_180_045) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_project_manager"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This is part one of several transactional email-related PRs.  This one does:

1.  Turn on Devise :confirmable.  
2. Migrate the db.  
3. Add protected method to user.rb so that users with unconfirmed emails can still log in.