### PR TITLE
Annotate Models with Database columns automatically

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -1,0 +1,58 @@
+---
+:position: before
+:position_in_additional_file_patterns: before
+:position_in_class: before
+:position_in_factory: before
+:position_in_fixture: before
+:position_in_routes: before
+:position_in_serializer: before
+:position_in_test: before
+:classified_sort: true
+:exclude_controllers: true
+:exclude_factories: false
+:exclude_fixtures: false
+:exclude_helpers: true
+:exclude_scaffolds: true
+:exclude_serializers: false
+:exclude_sti_subclasses: false
+:exclude_tests: false
+:force: false
+:format_markdown: false
+:format_rdoc: false
+:format_yard: false
+:frozen: false
+:ignore_model_sub_dir: false
+:ignore_unknown_models: false
+:include_version: false
+:show_check_constraints: false
+:show_complete_foreign_keys: false
+:show_foreign_keys: true
+:show_indexes: true
+:simple_indexes: false
+:sort: false
+:timestamp: false
+:trace: false
+:with_comment: true
+:with_column_comments: true
+:with_table_comments: true
+:active_admin: false
+:command:
+:debug: false
+:hide_default_column_types: ''
+:hide_limit_column_types: ''
+:ignore_columns:
+:ignore_routes:
+:models: true
+:routes: false
+:skip_on_db_migrate: false
+:target_action: :do_annotations
+:wrapper:
+:wrapper_close:
+:wrapper_open:
+:classes_default_to_s: []
+:additional_file_patterns: []
+:model_dir:
+- app/models
+:require: []
+:root_dir:
+- ''

--- a/Gemfile
+++ b/Gemfile
@@ -112,3 +112,5 @@ group :test do
 end
 
 gem "geocoder", "~> 1.8"
+
+gem "annotaterb", "~> 4.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       airbrake-ruby (~> 6.0)
     airbrake-ruby (6.2.1)
       rbtree3 (~> 0.6)
+    annotaterb (4.13.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.1045.0)
@@ -454,6 +455,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations (>= 2.0.2)
   airbrake
+  annotaterb (~> 4.13)
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: assessments
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  rating      :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  finisher_id :bigint
+#  skill_id    :bigint
+#
+# Indexes
+#
+#  index_assessments_on_finisher_id  (finisher_id)
+#  index_assessments_on_skill_id     (skill_id)
+#
 class Assessment < ApplicationRecord
   belongs_to :skill
   belongs_to :finisher

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: assignments
+#
+#  id          :bigint           not null, primary key
+#  ended_at    :datetime
+#  started_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  finisher_id :bigint
+#  project_id  :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_assignments_on_finisher_id  (finisher_id)
+#  index_assignments_on_project_id   (project_id)
+#  index_assignments_on_user_id      (user_id)
+#
 class Assignment < ApplicationRecord
   belongs_to :project
   belongs_to :finisher

--- a/app/models/assignment_update.rb
+++ b/app/models/assignment_update.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: assignment_updates
+#
+#  id            :bigint           not null, primary key
+#  description   :text
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assignment_id :bigint
+#  user_id       :bigint
+#
+# Indexes
+#
+#  index_assignment_updates_on_assignment_id  (assignment_id)
+#  index_assignment_updates_on_user_id        (user_id)
+#
 class AssignmentUpdate < ApplicationRecord
   belongs_to :assignment
   belongs_to :user

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: favorites
+#
+#  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  finisher_id :bigint
+#  product_id  :bigint
+#
+# Indexes
+#
+#  index_favorites_on_finisher_id  (finisher_id)
+#  index_favorites_on_product_id   (product_id)
+#
 class Favorite < ApplicationRecord
   belongs_to :product
   belongs_to :finisher

--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -1,5 +1,57 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: finishers
+#
+#  id                             :bigint           not null, primary key
+#  admin_notes                    :text
+#  approved_at                    :datetime
+#  can_publicize                  :boolean
+#  chosen_name                    :string
+#  city                           :string
+#  country                        :string
+#  description                    :text             not null
+#  dislikes                       :text
+#  dominant_hand                  :string
+#  emergency_contact_email        :string
+#  emergency_contact_name         :string
+#  emergency_contact_phone_number :string
+#  emergency_contact_relation     :string
+#  has_completed_profile          :boolean          default(FALSE)
+#  has_smoke_in_home              :boolean          default(FALSE)
+#  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_workplace_match            :boolean
+#  in_home_pets                   :string
+#  joined_on                      :date
+#  latitude                       :float
+#  longitude                      :float
+#  no_cats                        :boolean
+#  no_dogs                        :boolean
+#  no_smoke                       :boolean
+#  other_favorites                :text
+#  other_skills                   :text
+#  phone_number                   :string
+#  postal_code                    :string
+#  pronouns                       :string
+#  social_media                   :text
+#  state                          :string
+#  street                         :string
+#  street_2                       :string
+#  terms_of_use                   :boolean
+#  unavailable                    :boolean          default(FALSE)
+#  workplace_name                 :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  user_id                        :bigint           not null
+#
+# Indexes
+#
+#  index_finishers_on_joined_on  (joined_on)
+#  index_finishers_on_latitude   (latitude)
+#  index_finishers_on_longitude  (longitude)
+#  index_finishers_on_user_id    (user_id)
+#
 class Finisher < ApplicationRecord
   belongs_to :user
   validates :user, uniqueness: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: products
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Product < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :finishers, through: :favorites

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,68 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: projects
+#
+#  id                        :bigint           not null, primary key
+#  can_publicize             :boolean
+#  can_share_crafter_details :boolean          default(FALSE)
+#  can_use_first_name        :boolean          default(FALSE)
+#  city                      :string
+#  country                   :string
+#  craft_type                :string
+#  crafter_description       :text
+#  crafter_dominant_hand     :string
+#  crafter_name              :string
+#  description               :text
+#  group_project             :boolean          default(FALSE)
+#  has_pattern               :string
+#  has_smoke_in_home         :boolean          default(FALSE)
+#  in_home_pets              :string
+#  in_process_status         :string
+#  influencer                :boolean          default(FALSE)
+#  joann_helped              :boolean          default(FALSE)
+#  latitude                  :float
+#  longitude                 :float
+#  material_type             :string
+#  more_details              :text
+#  name                      :string           not null
+#  no_cats                   :boolean
+#  no_dogs                   :boolean
+#  no_smoke                  :boolean
+#  phone_number              :string
+#  postal_code               :string
+#  press                     :boolean          default(FALSE)
+#  press_outlet              :string
+#  press_region              :string
+#  privacy_needed            :boolean          default(FALSE)
+#  ready_status              :string
+#  recipient_name            :string
+#  state                     :string
+#  status                    :string           default("drafted"), not null
+#  street                    :string
+#  street_2                  :string
+#  terms_of_use              :boolean
+#  urgent                    :boolean          default(FALSE)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  group_manager_id          :bigint
+#  manager_id                :bigint
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_projects_on_group_manager_id  (group_manager_id)
+#  index_projects_on_latitude          (latitude)
+#  index_projects_on_longitude         (longitude)
+#  index_projects_on_manager_id        (manager_id)
+#  index_projects_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_manager_id => finishers.id)
+#  fk_rails_...  (manager_id => users.id)
+#
 class Project < ApplicationRecord
   STATUSES = [
     "drafted",

--- a/app/models/project_note.rb
+++ b/app/models/project_note.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: project_notes
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  project_id  :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_project_notes_on_project_id  (project_id)
+#  index_project_notes_on_user_id     (user_id)
+#
 class ProjectNote < ApplicationRecord
   belongs_to :project
   belongs_to :user

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: skills
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Skill < ApplicationRecord
   has_many :assessments, dependent: :destroy
   has_many :finishers, -> { where assessments: { rating: 1.. } }, through: :assessments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,34 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  first_name             :string           default(""), not null
+#  heard_about_us         :text
+#  is_project_manager     :boolean
+#  last_name              :string           default(""), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
+#  phone                  :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :string           default("user"), not null
+#  sign_in_count          :integer          default(0), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 class User < ApplicationRecord
   ROLES = %w[user manager admin].freeze
 

--- a/lib/tasks/annotate_rb.rake
+++ b/lib/tasks/annotate_rb.rake
@@ -1,0 +1,8 @@
+# This rake task was added by annotate_rb gem.
+
+# Can set `ANNOTATERB_SKIP_ON_DB_TASKS` to be anything to skip this
+if Rails.env.development? && ENV["ANNOTATERB_SKIP_ON_DB_TASKS"].nil?
+  require "annotate_rb"
+
+  AnnotateRb::Core.load_rake_tasks
+end

--- a/test/fixtures/assessments.yml
+++ b/test/fixtures/assessments.yml
@@ -1,4 +1,21 @@
 
+# == Schema Information
+#
+# Table name: assessments
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  rating      :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  finisher_id :bigint
+#  skill_id    :bigint
+#
+# Indexes
+#
+#  index_assessments_on_finisher_id  (finisher_id)
+#  index_assessments_on_skill_id     (skill_id)
+#
 knitter_assessment:
   skill: knit
   finisher_id: 2

--- a/test/fixtures/finishers.yml
+++ b/test/fixtures/finishers.yml
@@ -1,3 +1,55 @@
+# == Schema Information
+#
+# Table name: finishers
+#
+#  id                             :bigint           not null, primary key
+#  admin_notes                    :text
+#  approved_at                    :datetime
+#  can_publicize                  :boolean
+#  chosen_name                    :string
+#  city                           :string
+#  country                        :string
+#  description                    :text             not null
+#  dislikes                       :text
+#  dominant_hand                  :string
+#  emergency_contact_email        :string
+#  emergency_contact_name         :string
+#  emergency_contact_phone_number :string
+#  emergency_contact_relation     :string
+#  has_completed_profile          :boolean          default(FALSE)
+#  has_smoke_in_home              :boolean          default(FALSE)
+#  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_workplace_match            :boolean
+#  in_home_pets                   :string
+#  joined_on                      :date
+#  latitude                       :float
+#  longitude                      :float
+#  no_cats                        :boolean
+#  no_dogs                        :boolean
+#  no_smoke                       :boolean
+#  other_favorites                :text
+#  other_skills                   :text
+#  phone_number                   :string
+#  postal_code                    :string
+#  pronouns                       :string
+#  social_media                   :text
+#  state                          :string
+#  street                         :string
+#  street_2                       :string
+#  terms_of_use                   :boolean
+#  unavailable                    :boolean          default(FALSE)
+#  workplace_name                 :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  user_id                        :bigint           not null
+#
+# Indexes
+#
+#  index_finishers_on_joined_on  (joined_on)
+#  index_finishers_on_latitude   (latitude)
+#  index_finishers_on_longitude  (longitude)
+#  index_finishers_on_user_id    (user_id)
+#
 crocheter:
   id: 1
   user_id: 1

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -1,3 +1,66 @@
+# == Schema Information
+#
+# Table name: projects
+#
+#  id                        :bigint           not null, primary key
+#  can_publicize             :boolean
+#  can_share_crafter_details :boolean          default(FALSE)
+#  can_use_first_name        :boolean          default(FALSE)
+#  city                      :string
+#  country                   :string
+#  craft_type                :string
+#  crafter_description       :text
+#  crafter_dominant_hand     :string
+#  crafter_name              :string
+#  description               :text
+#  group_project             :boolean          default(FALSE)
+#  has_pattern               :string
+#  has_smoke_in_home         :boolean          default(FALSE)
+#  in_home_pets              :string
+#  in_process_status         :string
+#  influencer                :boolean          default(FALSE)
+#  joann_helped              :boolean          default(FALSE)
+#  latitude                  :float
+#  longitude                 :float
+#  material_type             :string
+#  more_details              :text
+#  name                      :string           not null
+#  no_cats                   :boolean
+#  no_dogs                   :boolean
+#  no_smoke                  :boolean
+#  phone_number              :string
+#  postal_code               :string
+#  press                     :boolean          default(FALSE)
+#  press_outlet              :string
+#  press_region              :string
+#  privacy_needed            :boolean          default(FALSE)
+#  ready_status              :string
+#  recipient_name            :string
+#  state                     :string
+#  status                    :string           default("drafted"), not null
+#  street                    :string
+#  street_2                  :string
+#  terms_of_use              :boolean
+#  urgent                    :boolean          default(FALSE)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  group_manager_id          :bigint
+#  manager_id                :bigint
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_projects_on_group_manager_id  (group_manager_id)
+#  index_projects_on_latitude          (latitude)
+#  index_projects_on_longitude         (longitude)
+#  index_projects_on_manager_id        (manager_id)
+#  index_projects_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_manager_id => finishers.id)
+#  fk_rails_...  (manager_id => users.id)
+#
 one:
   id: 1
   user_id: 5

--- a/test/fixtures/skills.yml
+++ b/test/fixtures/skills.yml
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: skills
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 knit:
   name: knit
   description: Basic knitting. Can knit and purl.

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  first_name             :string           default(""), not null
+#  heard_about_us         :text
+#  is_project_manager     :boolean
+#  last_name              :string           default(""), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
+#  phone                  :string           default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  role                   :string           default("user"), not null
+#  sign_in_count          :integer          default(0), not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
 basic:
   id: 1
   first_name: Bob

--- a/test/models/finisher_test.rb
+++ b/test/models/finisher_test.rb
@@ -1,5 +1,57 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: finishers
+#
+#  id                             :bigint           not null, primary key
+#  admin_notes                    :text
+#  approved_at                    :datetime
+#  can_publicize                  :boolean
+#  chosen_name                    :string
+#  city                           :string
+#  country                        :string
+#  description                    :text             not null
+#  dislikes                       :text
+#  dominant_hand                  :string
+#  emergency_contact_email        :string
+#  emergency_contact_name         :string
+#  emergency_contact_phone_number :string
+#  emergency_contact_relation     :string
+#  has_completed_profile          :boolean          default(FALSE)
+#  has_smoke_in_home              :boolean          default(FALSE)
+#  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_workplace_match            :boolean
+#  in_home_pets                   :string
+#  joined_on                      :date
+#  latitude                       :float
+#  longitude                      :float
+#  no_cats                        :boolean
+#  no_dogs                        :boolean
+#  no_smoke                       :boolean
+#  other_favorites                :text
+#  other_skills                   :text
+#  phone_number                   :string
+#  postal_code                    :string
+#  pronouns                       :string
+#  social_media                   :text
+#  state                          :string
+#  street                         :string
+#  street_2                       :string
+#  terms_of_use                   :boolean
+#  unavailable                    :boolean          default(FALSE)
+#  workplace_name                 :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  user_id                        :bigint           not null
+#
+# Indexes
+#
+#  index_finishers_on_joined_on  (joined_on)
+#  index_finishers_on_latitude   (latitude)
+#  index_finishers_on_longitude  (longitude)
+#  index_finishers_on_user_id    (user_id)
+#
 require "test_helper"
 
 class FinisherTest < ActiveSupport::TestCase

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,5 +1,68 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: projects
+#
+#  id                        :bigint           not null, primary key
+#  can_publicize             :boolean
+#  can_share_crafter_details :boolean          default(FALSE)
+#  can_use_first_name        :boolean          default(FALSE)
+#  city                      :string
+#  country                   :string
+#  craft_type                :string
+#  crafter_description       :text
+#  crafter_dominant_hand     :string
+#  crafter_name              :string
+#  description               :text
+#  group_project             :boolean          default(FALSE)
+#  has_pattern               :string
+#  has_smoke_in_home         :boolean          default(FALSE)
+#  in_home_pets              :string
+#  in_process_status         :string
+#  influencer                :boolean          default(FALSE)
+#  joann_helped              :boolean          default(FALSE)
+#  latitude                  :float
+#  longitude                 :float
+#  material_type             :string
+#  more_details              :text
+#  name                      :string           not null
+#  no_cats                   :boolean
+#  no_dogs                   :boolean
+#  no_smoke                  :boolean
+#  phone_number              :string
+#  postal_code               :string
+#  press                     :boolean          default(FALSE)
+#  press_outlet              :string
+#  press_region              :string
+#  privacy_needed            :boolean          default(FALSE)
+#  ready_status              :string
+#  recipient_name            :string
+#  state                     :string
+#  status                    :string           default("drafted"), not null
+#  street                    :string
+#  street_2                  :string
+#  terms_of_use              :boolean
+#  urgent                    :boolean          default(FALSE)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  group_manager_id          :bigint
+#  manager_id                :bigint
+#  user_id                   :bigint
+#
+# Indexes
+#
+#  index_projects_on_group_manager_id  (group_manager_id)
+#  index_projects_on_latitude          (latitude)
+#  index_projects_on_longitude         (longitude)
+#  index_projects_on_manager_id        (manager_id)
+#  index_projects_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_manager_id => finishers.id)
+#  fk_rails_...  (manager_id => users.id)
+#
 require "test_helper"
 
 class ProjectTest < ActiveSupport::TestCase


### PR DESCRIPTION
For easy access rake db:migrate now annotates models with the content of the database table they are associated with. 