### PR TITLE
Include required gems that are being removed from ruby 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,17 @@ gem "mini_magick"
 # Google Data
 gem "google_drive"
 
+# Geocoding
+gem "geocoder", "~> 1.8"
+
+# Annotated source code for Models
+gem "annotaterb", "~> 4.13"
+
+# Gems being moved out of core ruby
+gem "csv", "~> 3.3"
+gem "drb", "~> 2.2"
+gem "mutex_m", "~> 0.3.0"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]
@@ -110,7 +121,3 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
-
-gem "geocoder", "~> 1.8"
-
-gem "annotaterb", "~> 4.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
+    csv (3.3.2)
     date (3.4.1)
     debug (1.7.2)
       irb (>= 1.5.0)
@@ -142,6 +143,7 @@ GEM
       responders
       warden (~> 1.2.3)
     dotenv (3.1.7)
+    drb (2.2.1)
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -271,6 +273,7 @@ GEM
     msgpack (1.7.5)
     multi_json (1.15.0)
     multipart-post (2.4.1)
+    mutex_m (0.3.0)
     net-imap (0.5.5)
       date
       net-protocol
@@ -464,9 +467,11 @@ DEPENDENCIES
   capybara
   countries
   cssbundling-rails
+  csv (~> 3.3)
   debug
   devise
   dotenv
+  drb (~> 2.2)
   geocoder (~> 1.8)
   google_drive
   haml-rails
@@ -474,6 +479,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   mini_magick
+  mutex_m (~> 0.3.0)
   overcommit (~> 0.64.0)
   pg (~> 1.5.3)
   puma (~> 5.0)


### PR DESCRIPTION
Silence warnings about ruby 3.4.X

- drb
- csv
- mutex_m

```bash
warning: /root/.asdf/installs/ruby/3.3.7/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.

warning: /root/.asdf/installs/ruby/3.3.7/lib/ruby/3.3.0/drb.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.

You can add drb to your Gemfile or gemspec to silence this warning.
Also please contact the author of activesupport-7.0.8.7 to request adding drb into its gemspec.

```