### PR TITLE
Fixing bundle/bin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -526,4 +526,4 @@ RUBY VERSION
    ruby 3.3.7p123
 
 BUNDLED WITH
-   2.6.3
+   2.6.5

--- a/bin/bundle
+++ b/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV.fetch("BUNDLE_GEMFILE", nil)
-    return gemfile if gemfile.present?
+    return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path("../Gemfile", __dir__)
   end


### PR DESCRIPTION
Apparently rubocop updated bundle/bin and that is now breaking on heroku.  Reverting the change, see [here](https://stackoverflow.com/questions/67910193/heroku-bundler-undefined-method-present-fails-to-install-gems-via-bundler)
