### PR TITLE
Assignment status validation follow ups

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -32,7 +32,15 @@ class Assignment < ApplicationRecord
   validates :finisher_id, uniqueness: { scope: :project_id }
   validates :status, inclusion: { in: STATUS, allow_blank: true }
 
+  before_save :sanitize_status
+
   def self.active
     where(ended_at: nil)
+  end
+
+  private
+
+  def sanitize_status
+    self.status = nil if status.blank?
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -30,7 +30,7 @@ class Assignment < ApplicationRecord
   has_many :assignment_updates, dependent: :destroy
 
   validates :finisher_id, uniqueness: { scope: :project_id }
-  validates :status, inclusion: { in: STATUS }, allow_nil: true
+  validates :status, inclusion: { in: STATUS, allow_blank: true }
 
   def self.active
     where(ended_at: nil)

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -7,7 +7,7 @@
         = (assignment.status || 'Unknown').titleize
     - else
       = form.select :status,  [['Unknown', nil]] + Assignment::STATUS.map{|s| [s.titleize, s] }, {}, { class: 'form-select-sm', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
-    - if assignment.updated_at > 5.seconds.ago
+    - if assignment.saved_change_to_status?
       %span.update-flash.visible SAVED
 
 

--- a/test/controllers/manage/assignments_controller_test.rb
+++ b/test/controllers/manage/assignments_controller_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Manage
+  class AssignmentsControllerTest < ActionController::TestCase
+    setup do
+      @user = users(:admin)
+      sign_in @user
+    end
+
+    test "update can set status" do
+      assignment = assignments(:knit_active)
+      patch :update, params: { id: assignment.id, assignment: { status: "invited" } }
+
+      assert_response :redirect
+      assert_equal "invited", assignment.reload.status
+    end
+
+    test "update can clear status" do
+      assignment = assignments(:knit_active)
+      assignment.update!(status: "invited")
+      patch :update, params: { id: assignment.id, assignment: { status: "" } }
+
+      assert_response :redirect
+      assert_nil assignment.reload.status
+    end
+
+    test "turbo stream update renders saved label on update" do
+      assignment = assignments(:knit_active)
+      patch :update, params: { id: assignment.id, assignment: { status: "invited" } }, format: :turbo_stream
+
+      assert_response :success
+      assert_match(/SAVED/, response.body)
+    end
+
+    test "turbo stream update renders NO saved label if nothing changed" do
+      assignment = assignments(:knit_active)
+      assignment.update!(status: "invited")
+      patch :update, params: { id: assignment.id, assignment: { status: "invited" } }, format: :turbo_stream
+
+      assert_response :success
+      assert_no_match(/SAVED/, response.body)
+    end
+  end
+end

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -27,12 +27,14 @@ class AssignmentTest < ActiveSupport::TestCase
 
   test "all fixtures are valid by default" do
     Assignment.all.each do |assignment|
-      assert(assignment.valid?, "Assignment fixture should be valid: #{assignment.errors.full_messages.to_sentence}")
+      assert_predicate(assignment, :valid?,
+                       "Assignment fixture should be valid: #{assignment.errors.full_messages.to_sentence}")
     end
   end
 
   test "does not allow unknown status" do
     @assignment.status = "unknown"
+
     assert_not @assignment.valid?
     assert_includes @assignment.errors.full_messages, "Status is not included in the list"
   end
@@ -40,13 +42,21 @@ class AssignmentTest < ActiveSupport::TestCase
   test "allows known status" do
     Assignment::STATUS.each do |status|
       @assignment.status = status
-      assert @assignment.valid?, "Status #{status} should be valid"
+
+      assert_predicate @assignment, :valid?, "Status #{status} should be valid"
     end
   end
 
   test "allows nil status" do
     @assignment.status = nil
-    assert @assignment.valid?
+
+    assert_predicate @assignment, :valid?
+  end
+
+  test "allows empty string status" do
+    @assignment.status = ""
+
+    assert_predicate @assignment, :valid?
   end
 
   test "active scope" do

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -53,10 +53,13 @@ class AssignmentTest < ActiveSupport::TestCase
     assert_predicate @assignment, :valid?
   end
 
-  test "allows empty string status" do
+  test "empty status coerced into nil" do
     @assignment.status = ""
 
     assert_predicate @assignment, :valid?
+    @assignment.save!
+
+    assert_nil @assignment.reload.status
   end
 
   test "active scope" do


### PR DESCRIPTION
After deploying #100 there were a few issues managing projects. The root of this is that my original change did not take into account existing Assignment objects which would have a `nil` status. To fix this I changed `allow_nil` to `allow_blank` and added a `before_save` to normalize to `nil`. This means that the "Unknown" option in the form drop down (which sends an empty string) is now a valid option. This allows saving of existing records with no status or purposely choosing "Unknown". I've added model and controller tests to verify this.

A small visual issue was also fixed. The Assignment form was using the `Assignment#updated_at` and an arbitrary 5 second window to display the "SAVED" label. This meant that right after creation, or on page refresh soon after a change, it would be shown incorrectly. I changed this to use the `saved_change_to_status?` method provided by `ActiveModel::Dirty` so it matches the UX of that label correctly. Since this is a lesser used feature I also added a controller test for this label.