### PR TITLE
Add has_volunteer_time_off to finisher

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -55,7 +55,7 @@ h1.assigned
   margin-top: 1rem
 
 .form-info
-  font-size: 11px
+  font-size: .75rem
 
 
 .required:after

--- a/app/controllers/finishers_controller.rb
+++ b/app/controllers/finishers_controller.rb
@@ -98,6 +98,7 @@ class FinishersController < AuthenticatedController
       :has_smoke_in_home,
       :terms_of_use,
       :has_workplace_match,
+      :has_volunteer_time_off,
       :workplace_name,
       :emergency_contact_name,
       :emergency_contact_relation,

--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -21,6 +21,7 @@
 #  has_completed_profile          :boolean          default(FALSE)
 #  has_smoke_in_home              :boolean          default(FALSE)
 #  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_volunteer_time_off         :boolean          default(FALSE)
 #  has_workplace_match            :boolean
 #  in_home_pets                   :string
 #  joined_on                      :date

--- a/app/views/finishers/_profile_form.html.haml
+++ b/app/views/finishers/_profile_form.html.haml
@@ -41,6 +41,11 @@
           = form.select :has_workplace_match, [['Yes', true], ['No', false], ["I don't know", nil]], {}, {:class => 'form-select'}
       .row.g-1.g-sm-4.mb-4
         .col-12
+          = form.label 'has_volunteer_time_off', class: 'form-label' do
+            = form.check_box :has_volunteer_time_off
+            My company pays for volunteer time off
+      .row.g-1.g-sm-4.mb-4
+        .col-12
           = form.label 'If you do work outside the home what company do you work for?', class: 'form-label optional'
           = form.text_field :workplace_name, class: 'form-control'
 

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -35,6 +35,7 @@
       = finisher.products.map{|fav| fav.name}.join(', ')
 
 
-
+  - if finisher.has_volunteer_time_off?
+    %p.bg-success.px-2.text-white.font-weight-bold.mb-0.text-center VTO
   .card-footer
     #{finisher.city}, #{finisher.state}

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -1,5 +1,5 @@
 - classes ||= []
-%div{:class => [:card, finisher.active_assignments.any? && :assigned ]}
+%div{:class => [:card, finisher.active_assignments.any? && :assigned ].concat(classes)}
   - if finisher.unavailable
     .unavailable
       Unavailable

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -54,6 +54,9 @@
       %b Workplace Match?
       = @finisher.has_workplace_match == nil ? "I don't know" : @finisher.has_workplace_match ? "Yes" : "No"
     .page-section.mb-4
+      %b Volunteer Time Off?
+      = @finisher.has_volunteer_time_off? ? "Yes" : "No"
+    .page-section.mb-4
       %b Workplace:
       = @finisher.workplace_name
 

--- a/db/migrate/20250227211311_add_has_volunteer_time_off_to_finishers.rb
+++ b/db/migrate/20250227211311_add_has_volunteer_time_off_to_finishers.rb
@@ -1,0 +1,5 @@
+class AddHasVolunteerTimeOffToFinishers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :finishers, :has_volunteer_time_off, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_12_195851) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_27_211311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -466,6 +466,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_12_195851) do
     t.string "emergency_contact_phone_number"
     t.string "emergency_contact_email"
     t.string "emergency_contact_relation"
+    t.boolean "has_volunteer_time_off", default: false
     t.index ["joined_on"], name: "index_finishers_on_joined_on"
     t.index ["latitude"], name: "index_finishers_on_latitude"
     t.index ["longitude"], name: "index_finishers_on_longitude"

--- a/test/controllers/finishers_controller_test.rb
+++ b/test/controllers/finishers_controller_test.rb
@@ -28,12 +28,12 @@ class FinishersControllerTest < ActionController::TestCase
     # PATCH :update
     @address_params = {
       "finisher" => {
-        "country"=>"US",
-        "street"=>"123 Main St",
-        "street_2"=>"",
-        "city"=>"Anytown",
-        "state"=>"WA",
-        "postal_code"=>"12345"
+        "country" => "US",
+        "street" => "123 Main St",
+        "street_2" => "",
+        "city" => "Anytown",
+        "state" => "WA",
+        "postal_code" => "12345"
       }
     }
 
@@ -68,19 +68,39 @@ class FinishersControllerTest < ActionController::TestCase
 
   test "profile flow sends welcome & profile_complete messages" do
     post :create, params: @profile_params
+
     assert_redirected_to finisher_path
     assert_equal "Loose Ends Project Account Created - Next Steps...", ActionMailer::Base.deliveries.last.subject
 
     patch :update, params: @address_params
+
     assert_redirected_to finisher_path
     assert_equal "Loose Ends Project Account Created - Next Steps...", ActionMailer::Base.deliveries.last.subject
 
     patch :update, params: @skills_params
+
     assert_redirected_to finisher_path
     assert_equal "Loose Ends Project Account Created - Next Steps...", ActionMailer::Base.deliveries.last.subject
 
     patch :update, params: @favorites_params
+
     assert_redirected_to finisher_path
     assert_equal "Welcome, Loose Ends Finisher!", ActionMailer::Base.deliveries.last.subject
+  end
+
+  test "can update if the finisher has volunteer time off" do
+    post :create, params: @profile_params
+
+    finisher = Finisher.find_by(chosen_name: @profile_params["finisher"]["chosen_name"])
+
+    assert_not_nil(finisher)
+
+    @profile_params["finisher"].merge!("has_volunteer_time_off" => "true")
+
+    patch :update, params: @profile_params.merge("id" => finisher.id)
+
+    finisher.reload
+
+    assert(finisher.has_volunteer_time_off)
   end
 end

--- a/test/fixtures/finishers.yml
+++ b/test/fixtures/finishers.yml
@@ -19,6 +19,7 @@
 #  has_completed_profile          :boolean          default(FALSE)
 #  has_smoke_in_home              :boolean          default(FALSE)
 #  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_volunteer_time_off         :boolean          default(FALSE)
 #  has_workplace_match            :boolean
 #  in_home_pets                   :string
 #  joined_on                      :date

--- a/test/models/finisher_test.rb
+++ b/test/models/finisher_test.rb
@@ -21,6 +21,7 @@
 #  has_completed_profile          :boolean          default(FALSE)
 #  has_smoke_in_home              :boolean          default(FALSE)
 #  has_taken_ownership_of_profile :boolean          default(FALSE)
+#  has_volunteer_time_off         :boolean          default(FALSE)
 #  has_workplace_match            :boolean
 #  in_home_pets                   :string
 #  joined_on                      :date


### PR DESCRIPTION
- [x] Add a field (in a migration) to the finisher to indicate the employer will pay for their volunteer time off. has_vto.
- [x] Add a checkbox to the Edit Finisher (edit_profile) page, near the other charity questions. Get the actual text from Masey.
- [x] Add indicator to Finisher Profile and Finisher Card that shows if their employer will pay for their volunteer time.
- [ ] Update the Icon so these finishers stand out on the map. These finishers are special.