### PR TITLE
Minor copy changes for crafter and finisher

### DIFF
--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -1,7 +1,7 @@
 = form_for [:manage, assignment] do |form|
   .pb-2 Assigned to #{link_to(assignment.finisher.user.name, [ :manage, assignment.finisher ], data: { turbo_frame: :_top })} on #{assignment.created_at.to_formatted_s(:short)}
   .d-inline
-    = form.label 'Current Status', class: 'form-label'
+    = form.label 'Finisher Status', class: 'form-label'
     - if local_assigns[:readonly]
       %strong
         = (assignment.status || 'Unknown').titleize

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -50,7 +50,7 @@
 
   .row.mb-3
     .col-12
-      = form.label "About the crafter", class: 'form-label optional'
+      = form.label "About the original crafter", class: 'form-label optional'
     .col-6.col-sm-5.col-md-4
       .form-info Were there pets in the home?
       = form.collection_check_boxes(:in_home_pets, [ ['Dog(s)', 'dogs'], ['Cat(s)', 'cats'], ['Other', 'other'] ], :last, :first) do |b|

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -137,11 +137,14 @@
       .removeable_file
         = link_to file.blob.filename, url_for(file), { download: true }
         = button_to fa_icon("trash"), project_path(@project, { pattern_file_id: file.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
-    %h4 Crafter Details
-    = @project.crafter_name
-    = @project.crafter_description
-    - @project.crafter_images.each do |image|
-      = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), url_for(image.variant(format: :jpg))
+    %h4 Original Crafter Details
+    - if @project.crafter_name? || @project.crafter_description? || @project.crafter_images.any?
+      = @project.crafter_name
+      = @project.crafter_description
+      - @project.crafter_images.each do |image|
+        = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), url_for(image.variant(format: :jpg))
+    - else
+      .text-muted Not Provided
 
     %p= @project.crafter_dominant_hand
 
@@ -155,9 +158,14 @@
             %li No Cats Please
           - if @project.no_dogs
             %li No Dogs Please
+    - else
+      .text-muted Not Provided
 
     %h4 Recipient
-    = @project.recipient_name
+    - if @project.recipient_name?
+      = @project.recipient_name
+    - else
+      .text-muted Not Provided
 
   .col-3
     %h4

--- a/app/views/projects/_crafter_form.html.haml
+++ b/app/views/projects/_crafter_form.html.haml
@@ -1,7 +1,7 @@
 = form_with model: @project, html: { class: 'form', data: { turbo: false } } do |form|
   = render "error_messages", resource: @project
   .page-section
-    %h4 The Crafter
+    %h4 The Original Crafter
     .row.mb-2
       .col-4
         = form.label 'Name of deceased or compromised crafter', class: 'form-label required'

--- a/app/views/projects/_details.html.haml
+++ b/app/views/projects/_details.html.haml
@@ -61,7 +61,7 @@
     %h4
       .row
         .col-9
-          Crafter Details
+          Original Crafter Details
         .col-3
           = link_to 'Edit', [:edit_crafter, @project], class: 'btn btn-link float-end btn-sm'
 

--- a/app/views/projects/edit_crafter.html.haml
+++ b/app/views/projects/edit_crafter.html.haml
@@ -1,2 +1,2 @@
-= render 'title', title: 'Edit Crafter Details'
+= render 'title', title: 'Edit Original Crafter Details'
 = render 'crafter_form'

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -95,7 +95,7 @@
     %h4
       .row
         .col-9
-          Crafter Details
+          Original Crafter Details
         .col-3
           = link_to 'Edit', [:edit_crafter, @project], class: 'btn btn-link float-end btn-sm'
     - if !@project.crafter_name.present? && (!@project.crafter_description.present? || !@project.crafter_images.present?)


### PR DESCRIPTION
Change the UI from "crafter" to "original crafter" for clarity. This was part of a [few requested copy changes](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08G9DKUZPB), most of which were completed in #145. I also fixed a second [copy update](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08FYB13N14) for "Finisher Status". While reviewing I noticed that sections with no data were laid out oddly so I added a "Not Provided" message to those sections:

![New heading and placeholders](https://github.com/user-attachments/assets/b84e7d3f-01c0-45a4-9d4a-c855f09eb09f)
