### PR TITLE
Automatically run db:migrate on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,4 +6,7 @@ release: rake db:migrate
 
 # What is run on each web Dyno.
 web: bundle exec puma -C config/puma.rb
+
+# Pre-Puma version (before we used Procfile). Kept for easy rollback if
+# there are scaling issues.
 #web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,9 @@
+
+# Heroku launch configuration.
+
+# Run after the new code is built but before it is run on the Dyno(s)
+release: rake db:migrate
+
+# What is run on each web Dyno.
+web: bundle exec puma -C config/puma.rb
+#web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,14 +32,14 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Prevent me from [botching a deploy](https://looseendsproject.slack.com/archives/C05GUDK4620/p1741020997610329?thread_ts=1741018894.587149&cid=C05GUDK4620) by missing a `rake db:migrate`. This PR adds a `Procfile` that defines a [Heroku Release Phase](https://devcenter.heroku.com/articles/release-phase) with the `rake db:migrate` command. This will run the migration before the Dyno restarts to make sure that all Rails startups see the new database changes. While setting up the `Procfile` I also took [Heroku's recommendation to turn on Puma](https://devcenter.heroku.com/articles/ruby-default-web-server). A Puma configuration mostly existed with the small addition of `preload_app!`, which I've found in past projects stops the first few requests from being slow after a deploy or restart.

 I verified the migration and Puma work with [a staging deploy](https://dashboard.heroku.com/apps/looseends-staging/activity/builds/a9ed0623-8592-4399-a496-0c4073ca0ba8).