### PR TITLE
Rubocop formatting updates for plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 require:
   - rubocop-capybara
   - rubocop-minitest
+
+plugins:
   - rubocop-rails
+  - rubocop-performance
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -115,16 +115,18 @@ group :development do
   gem "bullet", "~> 8.0"
   gem "overcommit", "~> 0.64.0"
   gem "reek", "~> 6.4"
+
   gem "rubocop", "~> 1.69"
   gem "rubocop-capybara", "~> 2.21"
   gem "rubocop-minitest", "~> 0.36.0"
+  gem "rubocop-performance", "~> 1.24"
   gem "rubocop-rails", "~> 2.29"
 end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "rails-controller-testing"
   gem "selenium-webdriver"
   gem "webdrivers"
-  gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,10 @@ GEM
     rubocop-minitest (0.36.0)
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-performance (1.24.0)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-rails (2.30.3)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
@@ -526,6 +530,7 @@ DEPENDENCIES
   rubocop (~> 1.69)
   rubocop-capybara (~> 2.21)
   rubocop-minitest (~> 0.36.0)
+  rubocop-performance (~> 1.24)
   rubocop-rails (~> 2.29)
   sassc-rails
   selenium-webdriver


### PR DESCRIPTION
- Correcting `rubocop.yml` file to have plugins block for supported gems.
- Added `rubocop-performance` for best practices around ruby code performance
