### PR TITLE
Render pattern detail images in admin pages

### DIFF
--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -128,7 +128,8 @@
     .row
       - @project.material_images.each do |image|
         .removeable_image
-          = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), url_for(image.variant(format: :jpg))
+          = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
+          url_for(image.variant(format: :jpg)), target: "_blank"
           = button_to fa_icon("trash"), project_path(@project, { material_image_id: image.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
     %h4.mt-4
       .row
@@ -138,7 +139,8 @@
       Is there a pattern? #{@project.has_pattern}
     - @project.pattern_files.each do |file|
       .removeable_file
-        = link_to file.blob.filename, url_for(file), { download: true }
+        = link_to image_tag(file.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
+        url_for(file.variant(format: :jpg)), target: "_blank"
         = button_to fa_icon("trash"), project_path(@project, { pattern_file_id: file.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
     %h4 Original Crafter Details
     - if @project.crafter_name? || @project.crafter_description? || @project.crafter_images.any?


### PR DESCRIPTION
- Render image whenever there is a pattern.
- Open all images in new tab


Old:
![image](https://github.com/user-attachments/assets/5c0e0e64-0322-456e-9adc-5a5f308e7071)




New:
![image](https://github.com/user-attachments/assets/3420ab64-8bf9-4e48-a873-ff25592adaff)
