### PR TITLE
Add Material Brand to Project

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -78,15 +78,6 @@ h1.assigned
   left: 2px
   line-height: 1.2
 
-.manager-only:after
-  font-size: 1rem
-  content: " (manager visible only)"
-  color: $warning
-  position: relative
-  bottom: 0
-  left: 2px
-  line-height: 1.2
-
 .field_with_errors
   display: inline-block
 

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -78,6 +78,15 @@ h1.assigned
   left: 2px
   line-height: 1.2
 
+.manager-only:after
+  font-size: 1rem
+  content: " (manager visible only)"
+  color: $warning
+  position: relative
+  bottom: 0
+  left: 2px
+  line-height: 1.2
+
 .field_with_errors
   display: inline-block
 

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -59,7 +59,7 @@ module Manage
     def add_csv_headers
       response.headers["Content-Type"] = "text/csv"
       response.headers["Content-Disposition"] =
-          "attachment; filename=#{@title.parameterize}-#{DateTime.now.strftime("%Y-%m-%d-%H%M")}.csv"
+        "attachment; filename=#{@title.parameterize}-#{DateTime.now.strftime("%Y-%m-%d-%H%M")}.csv"
     end
 
     def status_counts
@@ -87,6 +87,7 @@ module Manage
         :craft_type,
         :has_pattern,
         :material_type,
+        :material_brand,
         :crafter_name,
         :crafter_description,
         :crafter_dominant_hand,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,7 @@
 #  joann_helped              :boolean          default(FALSE)
 #  latitude                  :float
 #  longitude                 :float
+#  material_brand            :text
 #  material_type             :string
 #  more_details              :text
 #  name                      :string           not null
@@ -106,7 +107,8 @@ class Project < ApplicationRecord
   search_query_joins :user
   search_sort_name_field :name
   search_text_fields :"projects.name", :"projects.description", :"projects.craft_type", :"projects.material_type",
-                     :"projects.city", :"projects.state", :"users.first_name", :"users.last_name", :"users.email"
+                     :"projects.material_brand", :"projects.city", :"projects.state", :"users.first_name",
+                     :"users.last_name", :"users.email"
   search_default_sort "date desc"
 
   belongs_to :manager, optional: true, class_name: "User"

--- a/app/views/layouts/_address_form.html.haml
+++ b/app/views/layouts/_address_form.html.haml
@@ -1,5 +1,5 @@
 #country_ui.row
-  .col-4
+  .col-md-4
     = form.label 'Country', class: 'form-label required'
     = form.select :country, options_for_select(ISO3166::Country.pluck(:iso_short_name, :alpha2).sort_by{|c| I18n.transliterate(c[0])}, form.object.country), { include_blank: true }, { class: 'form-select', onChange: "setStates(this.value)", id: 'country' }
   .row.my-2

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -25,19 +25,19 @@
       = form.select :in_process_status, Project::IN_PROCESS_STATUSES.map { |status| [status.humanize.gsub(/\bpo\b/i, 'PO'), status] }, { include_blank: true }, { class: 'form-select' }
 
   .row.mb-4
-    .col-6
+    .col-md-6
       = form.label 'Phone Number', class: 'form-label required'
       = form.text_field :phone_number, class: 'form-control'
   .row.mb-4
-    .col-6
+    .col-md-6
       = form.label 'Craft Kind', class: 'form-label required'
       = form.text_field :craft_type, class: 'form-control'
   .row.mb-4
-    .col-6
+    .col-md-6
       = form.label 'What was being made?', class: 'form-label required'
       = form.text_area :description, size: "60x5", class: 'form-control'
   .row.mb-4
-    .col-4
+    .col-md-4
       = form.label 'Project Images', class: 'form-label required'
       .form-info Please upload photos of the unfinished project.
       = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
@@ -88,12 +88,18 @@
   .page-section
     %h5 Material
     .row.mb-2
-      .col-6
+      .col-md-6
         = form.label 'What kind of yarn / material is used?', class: 'form-label required'
         .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc).
         = form.text_field :material_type, class: 'form-control'
+    - if current_user.can_manage?
+      .row
+        .col-md-6
+          = form.label 'What brand is the material?', class: 'form-label manager-only'
+          .form-info Berocco, Lion, etc.
+          = form.text_field :material_brand, class: 'form-control'
     .row.mb-2
-      .col-4
+      .col-md-4
         = form.label 'Material Images', class: 'form-label'
         .form-info Photo of the materials (yarn, fabric) used. Please be sure to include any labels and branding, if possible.
         = form.file_field :append_material_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
@@ -102,11 +108,11 @@
   .page-section
     %h5 Pattern
     .row.mb-2
-      .col-2
+      .col-md-2
         = form.label 'Is there a pattern?', class: 'form-label required'
         = form.select :has_pattern, ['Yes', 'No', "I don't know"], { include_blank: true }, { class: 'form-select' }
     .row.mb-2
-      .col-4
+      .col-md-4
         = form.label 'Pattern Files', class: 'form-label'
         .form-info Please upload images or PDFs of the pattern, if you have them.
         = form.file_field :append_pattern_files, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp,application/pdf", :multiple => true
@@ -163,7 +169,7 @@
   .page-section
     %h5 Other Details
     .row.mb-2
-      .col-6
+      .col-md-6
         = form.label 'Are there any other details you can offer, or anything else we should know about finishing this project?', class: 'form-label'
         = form.text_area :more_details, size: "60x5", class: 'form-control'
 

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -92,12 +92,11 @@
         = form.label 'What kind of yarn / material is used?', class: 'form-label required'
         .form-info Wool, Cotton, Linen, Synthetic (Nylon, Polyester, Acrylic, etc).
         = form.text_field :material_type, class: 'form-control'
-    - if current_user.can_manage?
-      .row
-        .col-md-6
-          = form.label 'What brand is the material?', class: 'form-label manager-only'
-          .form-info Berocco, Lion, etc.
-          = form.text_field :material_brand, class: 'form-control'
+    .row
+      .col-md-6
+        = form.label 'What brand is the material?', class: 'form-label'
+        .form-info Berocco, Lion, etc.
+        = form.text_field :material_brand, class: 'form-control'
     .row.mb-2
       .col-md-4
         = form.label 'Material Images', class: 'form-label'

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -123,11 +123,13 @@
       %hr/
     %h4 Material Details
     .row
-      %b Type:
-      = @project.material_type
+      %b.col-auto Type:
+      .col
+        = @project.material_type
     .row
-      %b Brand:
-      = @project.material_brand
+      %b.col-auto Brand:
+      .col
+        = @project.material_brand
     .row
       - @project.material_images.each do |image|
         .removeable_image

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -126,6 +126,9 @@
       %b Type:
       = @project.material_type
     .row
+      %b Brand:
+      = @project.material_brand
+    .row
       - @project.material_images.each do |image|
         .removeable_image
           = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |

--- a/db/migrate/20250312164001_add_material_brand_to_projects.rb
+++ b/db/migrate/20250312164001_add_material_brand_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMaterialBrandToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :material_brand, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_250_308_235_102) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_12_164001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -216,6 +216,7 @@ ActiveRecord::Schema[7.0].define(version: 20_250_308_235_102) do
     t.string "press_outlet"
     t.boolean "can_use_first_name", default: false
     t.boolean "can_share_crafter_details", default: false
+    t.text "material_brand"
     t.index ["group_manager_id"], name: "index_projects_on_group_manager_id"
     t.index ["latitude"], name: "index_projects_on_latitude"
     t.index ["longitude"], name: "index_projects_on_longitude"

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -40,7 +40,7 @@ module Manage
       get "/manage/projects"
       projects = assigns(:projects)
 
-      assert(projects[0].created_at > projects[1].created_at)
+      assert_operator(projects[0].created_at, :>, projects[1].created_at)
     end
 
     test "index sort by created_at desc returns results in new order" do
@@ -48,7 +48,7 @@ module Manage
       get "/manage/projects?sort=created_at+asc"
       projects = assigns(:projects)
 
-      assert(projects[0].created_at < projects[1].created_at)
+      assert_operator(projects[0].created_at, :<, projects[1].created_at)
     end
 
     test "CSV export metadata" do
@@ -87,6 +87,16 @@ module Manage
       assert_response :success
     end
 
+    test "show includes material brand" do
+      sign_in @user
+      @project.update!(material_brand: "brandname")
+
+      get manage_project_path(@project)
+
+      assert_response :success
+      assert_select "div", text: "brandname"
+    end
+
     test "edit loads" do
       sign_in @user
       get "/manage/projects/#{@project.id}/edit"
@@ -102,6 +112,14 @@ module Manage
 
       assert_redirected_to manage_project_path(@project)
       assert_equal("New Name", @project.reload.name)
+    end
+
+    test "update updates material brand" do
+      sign_in @user
+      patch "/manage/projects/#{@project.id}", params: { project: { material_brand: "brandname" } }
+
+      assert_redirected_to manage_project_path(@project)
+      assert_equal("brandname", @project.reload.material_brand)
     end
 
     test "create with incomplete params renders page" do
@@ -218,7 +236,7 @@ module Manage
       get "/manage/projects", params: params
 
       assert_response :success
-      assert_select "a[href=?]", %r[/manage/projects/\d+], count: 0
+      assert_select "a[href=?]", %r{/manage/projects/\d+}, count: 0
     end
 
     def new_project_params

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -69,6 +69,15 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_equal "Updated Name", @project.reload.name
   end
 
+  test "should not include the manager-only material_brand field" do
+    @project.update!(material_brand: "brandname")
+
+    sign_in @project.user
+    get :show, params: { id: @project }
+
+    assert_no_match(/brandname/, response.body)
+  end
+
   test "should show terms of service" do
     sign_in users(:project_owner)
     get :new
@@ -84,4 +93,3 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_select "h5", { text: "Terms of Service", count: 0 }
   end
 end
-

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -22,6 +22,7 @@
 #  joann_helped              :boolean          default(FALSE)
 #  latitude                  :float
 #  longitude                 :float
+#  material_brand            :text
 #  material_type             :string
 #  more_details              :text
 #  name                      :string           not null

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -24,6 +24,7 @@
 #  joann_helped              :boolean          default(FALSE)
 #  latitude                  :float
 #  longitude                 :float
+#  material_brand            :text
 #  material_type             :string
 #  more_details              :text
 #  name                      :string           not null


### PR DESCRIPTION
Add "Material Brand" attribute to `Project` as `material_brand`. The  [Slack list item](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08G364C8BF) had a few requirements:

1. Only displayed and editable in the manager view
2. Should be searchable

While I was adding this I also cleaned up the form display on narrower viewports as that's often how I side-by-side test.

## Updated Display

![Project manage show](https://github.com/user-attachments/assets/dc752b0f-41cc-4dd0-ba87-db146d885e3e)

## Updated edit in wide and narrow viewports

![Project manage edit view, wide](https://github.com/user-attachments/assets/6883b2db-2ebd-4bba-a633-55b63c54d6b1)

![Project manage edit view,  narrow](https://github.com/user-attachments/assets/44b951b4-f9b3-479c-a1b6-48e0670f6bf4)


