### PR TITLE
Project submission UI updates

### DIFF
--- a/app/views/application/_navigation.html.haml
+++ b/app/views/application/_navigation.html.haml
@@ -2,7 +2,7 @@
   %nav.navbar.navbar-expand-xl
     .container-fluid
       .navbar-header
-        = link_to image_tag('looseendslogo.png', class: 'logo mx-3 my-1', :height => '48'), root_path
+        = link_to image_tag('looseendslogo.png', alt: "Loose Ends Home", class: 'logo mx-3 my-1', :height => '48'), root_path
       %button.navbar-toggler{:type => "button", :data => { :"bs-toggle" => 'collapse', :"bs-target" => '#navbarSupportedContent'}, aria: { controls: 'navbarSupportedContent', expanded: 'false', label: 'Toggle Navigation'}}
         %span.sr-only Toggle navigation
         = fa_icon('bars')

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{xmlns: "http://www.w3.org/1999/xhtml", "xml:lang" => "en-US", lang: "en-US"}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= display_env + (@title || "Loose Ends - Admin")

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{xmlns: "http://www.w3.org/1999/xhtml", "xml:lang" => "en-US", lang: "en-US"}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= display_env + (@title || "Loose Ends - Home")

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{xmlns: "http://www.w3.org/1999/xhtml", "xml:lang" => "en-US", lang: "en-US"}
   %head
     %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}
     :css

--- a/app/views/layouts/manage.html.haml
+++ b/app/views/layouts/manage.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{xmlns: "http://www.w3.org/1999/xhtml", "xml:lang" => "en-US", lang: "en-US"}
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title

--- a/app/views/projects/_basics_form.html.haml
+++ b/app/views/projects/_basics_form.html.haml
@@ -22,7 +22,7 @@
           .row.mb-2
             .col-8
               = form.label 'terms_of_use', class: 'form-label required' do
-                = form.check_box :terms_of_use
+                = form.check_box :terms_of_use, required: true
                 I agree.
   .form-actions
     = form.submit 'Submit', class: "btn btn-primary"

--- a/app/views/projects/_basics_form.html.haml
+++ b/app/views/projects/_basics_form.html.haml
@@ -1,56 +1,38 @@
 = form_with model: @project, html: { class: 'form', data: { turbo: false } } do |form|
   = render "error_messages", resource: @project
+  %h2 Project Details
+  %hr
+  = render 'project_form_fields', form: form
+
+  %h2 Your Details
+  %hr
+  = render 'submitter_form_fields', form: form
+
+  %h2 Can we talk about this project?
+  %hr
   .row
-    .col-4
-      = form.label 'Give this project a name', class: 'form-label required'
-      = form.text_field :name, class: 'form-control'
-  .row
-    .col-4
-      = form.label 'Your Cell Phone Number', class: 'form-label required'
-      .form-info Loose Ends Project may reach out to you via text message.
-      = form.text_field :phone_number, class: 'form-control'
-  .page-section
-    %h5 Project
-    .row.mb-2
-      .col-6
-        = form.label 'What type of craft project are you submitting?', class: 'form-label required'
-        .form-info Knit, Crochet, Quilt. If you do not know, say "I don't know."
-        = form.text_field :craft_type, class: 'form-control'
-    .row.mb-2
-      .col-6
-        = form.label 'What was being made?', class: 'form-label required'
-        .form-info (for instance, sweater, socks, blanket, hat...)
-        = form.text_area :description, size: "60x5", class: 'form-control'
-    .row.mb-2
-      .col-4
-        = form.label 'Project Images', class: 'form-label required'
-        .form-info Please upload photos of the unfinished project.
-        = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
-        - form.object.project_images.each do |image|
-          - if image.id.present? # Rails bug https://github.com/rails/rails/issues/50234
-            = image_tag image.representation(resize_to_limit: [100, 100])
-  .row.mb-2
-    .col-8
-      .page-section#permissions
-        %h5 Can we talk about this project?
-        .form-info
-          Sharing images of projects helps others understand what it's like to be a part of Loose Ends. May we have your permission to post photos of your project online, including on our social media? Your personal information will be kept confidential.
+    .col-md-8
+      %p
+        Sharing images of projects helps others understand what it's like to be a part of Loose Ends. May we have your permission to post photos of your project online, including on our social media? Your personal information will be kept confidential.
       = form.label 'can_publicize', class: 'form-label my-2' do
         = form.check_box :can_publicize
         Loose Ends Project has permission to post about my project online, including on social media.
-      = form.label 'can_use_first_name', class: 'form-label my-2' do
+      = form.label 'can_use_first_name', class: 'form-label mt-2 mb-4' do
         = form.check_box :can_use_first_name
         Loose Ends Project has permission to use my first name in posts online.
+
   - if !@project.persisted?
-    .row.mb-2
-      .col-8
-        %h5 Terms of Service
-        By clicking below, you agree that Loose Ends Project and its volunteers are not responsible for lost or damaged projects or materials and that although we thoughtfully match each project to skilled volunteers, there is a chance that your finished piece may have imperfections. By clicking here you also acknowledge that you understand that Loose Ends volunteers are not under any time pressure, or obligation to finish projects under a deadline.
-    .row.mb-2
-      .col-8
-        = form.label 'terms_of_use', class: 'form-label required' do
-          = form.check_box :terms_of_use
-          I agree.
+    %h2 Terms of Service
+    %hr
+      .row
+        .col-md-8
+          %p
+            By clicking below, you agree that Loose Ends Project and its volunteers are not responsible for lost or damaged projects or materials and that although we thoughtfully match each project to skilled volunteers, there is a chance that your finished piece may have imperfections. By clicking here you also acknowledge that you understand that Loose Ends volunteers are not under any time pressure, or obligation to finish projects under a deadline.
+          .row.mb-2
+            .col-8
+              = form.label 'terms_of_use', class: 'form-label required' do
+                = form.check_box :terms_of_use
+                I agree.
   .form-actions
     = form.submit 'Submit', class: "btn btn-primary"
     - if @project.persisted?

--- a/app/views/projects/_basics_form.html.haml
+++ b/app/views/projects/_basics_form.html.haml
@@ -10,16 +10,7 @@
 
   %h2 Can we talk about this project?
   %hr
-  .row
-    .col-md-8
-      %p
-        Sharing images of projects helps others understand what it's like to be a part of Loose Ends. May we have your permission to post photos of your project online, including on our social media? Your personal information will be kept confidential.
-      = form.label 'can_publicize', class: 'form-label my-2' do
-        = form.check_box :can_publicize
-        Loose Ends Project has permission to post about my project online, including on social media.
-      = form.label 'can_use_first_name', class: 'form-label mt-2 mb-4' do
-        = form.check_box :can_use_first_name
-        Loose Ends Project has permission to use my first name in posts online.
+  = render 'publicity_form_fields', form: form
 
   - if !@project.persisted?
     %h2 Terms of Service

--- a/app/views/projects/_project_form_fields.html.haml
+++ b/app/views/projects/_project_form_fields.html.haml
@@ -1,0 +1,26 @@
+.row.mb-4
+  .col-md-4
+    = form.label 'Give this project a name', class: 'form-label required'
+  .col-md-4
+    = form.text_field :name, class: 'form-control'
+.row.mb-4
+  .col-md-4
+    = form.label 'What was being made?', class: 'form-label required'
+  .col-md-4
+    = form.text_area :description, size: "60x5", class: 'form-control'
+    .form-info (for instance, sweater, socks, blanket, hat...)
+.row.mb-4
+  .col-md-4
+    = form.label 'What type of craft?', class: 'form-label required'
+  .col-md-4
+    = form.text_field :craft_type, class: 'form-control'
+    .form-info Knit, Crochet, Quilt. If you do not know, say "I don't know."
+.row.mb-4
+  .col-md-4
+    = form.label 'Project Images', class: 'form-label required'
+  .col-md-4
+    = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
+    - form.object.project_images.each do |image|
+      = image_tag image.representation( resize_to_limit: [100, 100])
+    .form-info Please upload photos of the unfinished project.
+  

--- a/app/views/projects/_project_form_fields.html.haml
+++ b/app/views/projects/_project_form_fields.html.haml
@@ -1,23 +1,23 @@
 .row.mb-4
   .col-md-4
-    = form.label 'Give this project a name', class: 'form-label required'
+    = form.label :name, 'Give this project a name', class: 'form-label required'
   .col-md-4
     = form.text_field :name, class: 'form-control'
 .row.mb-4
   .col-md-4
-    = form.label 'What was being made?', class: 'form-label required'
+    = form.label :description, 'What was being made?', class: 'form-label required'
   .col-md-4
     = form.text_area :description, size: "60x5", class: 'form-control'
     .form-info (for instance, sweater, socks, blanket, hat...)
 .row.mb-4
   .col-md-4
-    = form.label 'What type of craft?', class: 'form-label required'
+    = form.label :craft_type, 'What type of craft?', class: 'form-label required'
   .col-md-4
     = form.text_field :craft_type, class: 'form-control'
     .form-info Knit, Crochet, Quilt. If you do not know, say "I don't know."
 .row.mb-4
   .col-md-4
-    = form.label 'Project Images', class: 'form-label required'
+    = form.label :append_project_images, 'Project Images', class: 'form-label required'
   .col-md-4
     = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
     - form.object.project_images.each do |image|

--- a/app/views/projects/_project_form_fields.html.haml
+++ b/app/views/projects/_project_form_fields.html.haml
@@ -21,6 +21,7 @@
   .col-md-4
     = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true, required: true
     - form.object.project_images.each do |image|
-      = image_tag image.representation( resize_to_limit: [100, 100])
+      - if image.id.present? # Rails bug https://github.com/rails/rails/issues/50234
+        = image_tag image.representation(resize_to_limit: [100, 100])
     .form-info Please upload photos of the unfinished project.
   

--- a/app/views/projects/_project_form_fields.html.haml
+++ b/app/views/projects/_project_form_fields.html.haml
@@ -19,7 +19,7 @@
   .col-md-4
     = form.label :append_project_images, 'Project Images', class: 'form-label required'
   .col-md-4
-    = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true, required: true
+    = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true, required: form.object.project_images.none?
     - form.object.project_images.each do |image|
       - if image.id.present? # Rails bug https://github.com/rails/rails/issues/50234
         = image_tag image.representation(resize_to_limit: [100, 100])

--- a/app/views/projects/_project_form_fields.html.haml
+++ b/app/views/projects/_project_form_fields.html.haml
@@ -2,24 +2,24 @@
   .col-md-4
     = form.label :name, 'Give this project a name', class: 'form-label required'
   .col-md-4
-    = form.text_field :name, class: 'form-control'
+    = form.text_field :name, class: 'form-control', required: true
 .row.mb-4
   .col-md-4
     = form.label :description, 'What was being made?', class: 'form-label required'
   .col-md-4
     = form.text_area :description, size: "60x5", class: 'form-control'
-    .form-info (for instance, sweater, socks, blanket, hat...)
+    .form-info (for instance, sweater, socks, blanket, hat...), required: true
 .row.mb-4
   .col-md-4
     = form.label :craft_type, 'What type of craft?', class: 'form-label required'
   .col-md-4
-    = form.text_field :craft_type, class: 'form-control'
+    = form.text_field :craft_type, class: 'form-control', required: true
     .form-info Knit, Crochet, Quilt. If you do not know, say "I don't know."
 .row.mb-4
   .col-md-4
     = form.label :append_project_images, 'Project Images', class: 'form-label required'
   .col-md-4
-    = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
+    = form.file_field :append_project_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true, required: true
     - form.object.project_images.each do |image|
       = image_tag image.representation( resize_to_limit: [100, 100])
     .form-info Please upload photos of the unfinished project.

--- a/app/views/projects/_publicity_form_fields.html.haml
+++ b/app/views/projects/_publicity_form_fields.html.haml
@@ -1,0 +1,10 @@
+.row
+  .col-md-8
+    %p
+      Sharing images of projects helps others understand what it's like to be a part of Loose Ends. May we have your permission to post photos of your project online, including on our social media? Your personal information will be kept confidential.
+    = form.label 'can_publicize', class: 'form-label my-2' do
+      = form.check_box :can_publicize
+      Loose Ends Project has permission to post about my project online, including on social media.
+    = form.label 'can_use_first_name', class: 'form-label mt-2 mb-4' do
+      = form.check_box :can_use_first_name
+      Loose Ends Project has permission to use my first name in posts online.

--- a/app/views/projects/_submitter_form_fields.html.haml
+++ b/app/views/projects/_submitter_form_fields.html.haml
@@ -1,6 +1,6 @@
 .row.mb-4
   .col-md-4
-    = form.label 'Your Cell Phone Number', class: 'form-label required'
+    = form.label :phone_number, 'Your Cell Phone Number', class: 'form-label required'
   .col-md-4
     = form.text_field :phone_number, class: 'form-control'
     .form-info Loose Ends Project may reach out to you via text message.

--- a/app/views/projects/_submitter_form_fields.html.haml
+++ b/app/views/projects/_submitter_form_fields.html.haml
@@ -1,0 +1,6 @@
+.row.mb-4
+  .col-md-4
+    = form.label 'Your Cell Phone Number', class: 'form-label required'
+  .col-md-4
+    = form.text_field :phone_number, class: 'form-control'
+    .form-info Loose Ends Project may reach out to you via text message.

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -82,7 +82,7 @@ class ProjectsControllerTest < ActionController::TestCase
     sign_in users(:project_owner)
     get :new
 
-    assert_select "h5", { text: "Terms of Service" }
+    assert_select "h2", { text: "Terms of Service" }
   end
 
   test "should not show terms of service" do


### PR DESCRIPTION
I was gonna pick up the tickets to add Original Crafter details as required fields to the project submission form.

But I found myself doing a lot of reorganizing and I didn't want my PR to bloat too much.

This PR doesn't make any logic changes. It uses [Julie's designs](https://www.figma.com/design/X09cMIMc6r5j0T5dSimrLv/Loose-Ends-Project?node-id=66-6484&t=lXPenDr5MYomjyNb-1) as a reference 

## Changes
- Some small accessibility fixes 
  - HTML lang attrs
  - image alt for the main nav logo 
  - correctly associate labels with their inputs for screen readers and keyboard nav
- Separate the project submission form into a couple partials 
  - I'd like to use these in subsequent PRs to reorganize the edit project screens to more closely match the new sections/organization
- Make necessary inputs required on the frontend to prevent form submission if they're not filled out

## Project submission form BEFORE
![screencapture-localhost-3000-projects-new-2025-03-16-14_04_19](https://github.com/user-attachments/assets/86b43770-eb6d-4ea5-84b6-b0416b118f07)

## Project submission form AFTER
![screencapture-localhost-3000-projects-new-2025-03-16-14_10_49](https://github.com/user-attachments/assets/77bbc24c-b1dc-433b-9e49-63e390441b2f)

## Edit project BEFORE
![screencapture-localhost-3000-projects-11-edit-basics-2025-03-16-14_04_07](https://github.com/user-attachments/assets/3fd91ede-46e4-43d9-a99f-691a925087af)

## Edit project AFTER
![screencapture-localhost-3000-projects-11-edit-basics-2025-03-16-14_11_11](https://github.com/user-attachments/assets/c5011239-242e-4f8f-9dfd-363b06d24a35)
