### PR TITLE
Add last contact date to Assignment

### DIFF
--- a/app/controllers/manage/project_notes_controller.rb
+++ b/app/controllers/manage/project_notes_controller.rb
@@ -8,6 +8,9 @@ module Manage
       @project_note = @project.project_notes.new(project_notes_params)
       @project_note.user = current_user
       @project_note.save
+
+      update_last_contacted! if params[:finisher_contact]
+
       respond_to do |format|
         format.turbo_stream {}
       end
@@ -29,6 +32,15 @@ module Manage
 
     def project_notes_params
       params.require(:project_note).permit([:description])
+    end
+
+    def update_last_contacted!
+      return if @project.active_finisher.blank?
+
+      assignment = @project.assignments.where(finisher: @project.active_finisher).first
+      return if assignment.blank?
+
+      assignment.update_attribute!(:last_contacted_at, Time.zone.now)
     end
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -4,15 +4,16 @@
 #
 # Table name: assignments
 #
-#  id          :bigint           not null, primary key
-#  ended_at    :datetime
-#  started_at  :datetime
-#  status      :text
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  finisher_id :bigint
-#  project_id  :bigint
-#  user_id     :bigint
+#  id                :bigint           not null, primary key
+#  ended_at          :datetime
+#  last_contacted_at :datetime
+#  started_at        :datetime
+#  status            :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  finisher_id       :bigint
+#  project_id        :bigint
+#  user_id           :bigint
 #
 # Indexes
 #

--- a/app/views/manage/project_notes/_form.html.haml
+++ b/app/views/manage/project_notes/_form.html.haml
@@ -5,9 +5,10 @@
   .row.my-2
     .col
       = check_box_tag :finisher_contact, '1', false, class: 'form-check-input', autocomplete: 'off'
-      = label_tag :finisher_contact, "Finisher contact?", class: 'd-inline form-control-sm form-check-label'
-    .col-auto
-      = f.submit 'Submit', { id: 'project_note_form_submit_button', disabled: 'true', class: "btn btn-primary" }
+      = label_tag :finisher_contact, "Contact from Finisher?", class: 'd-inline form-control-sm form-check-label'
+  .row.my-2
+    .col.clearfix
+      = f.submit 'Submit', { id: 'project_note_form_submit_button', disabled: 'true', class: "btn btn-primary float-end" }
 
 :javascript
   document.getElementById('project_note_description').addEventListener('input', () => {

--- a/app/views/manage/project_notes/_form.html.haml
+++ b/app/views/manage/project_notes/_form.html.haml
@@ -4,6 +4,9 @@
       = f.text_area :description, size: "60x4", class: 'form-control'
   .row.my-2
     .col
+      = check_box_tag :finisher_contact, '1', false, class: 'form-check-input', autocomplete: 'off'
+      = label_tag :finisher_contact, "Finisher contact?", class: 'd-inline form-control-sm form-check-label'
+    .col-auto
       = f.submit 'Submit', { id: 'project_note_form_submit_button', disabled: 'true', class: "btn btn-primary" }
 
 :javascript

--- a/app/views/manage/projects/_project_card.html.haml
+++ b/app/views/manage/projects/_project_card.html.haml
@@ -25,7 +25,7 @@
         %li.highlighted
           = fa_icon("user", title: 'Active Finisher')
           %span #{project.active_finisher.name}
-        - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('updated_at')
+        - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('last_contacted_at')
           %li
             = fa_icon("envelope", title: 'Last Contact')
             = time_tag(last_contact, "Contact #{time_ago_in_words(last_contact)} ago", title: last_contact)

--- a/app/views/manage/projects/_project_row.html.haml
+++ b/app/views/manage/projects/_project_row.html.haml
@@ -3,7 +3,7 @@
   %td.text-nowrap= project.status.titleize
   %td.text-nowrap= time_tag(project.updated_at, "#{time_ago_in_words(project.updated_at)} ago", title: project.updated_at)
   %td.text-nowrap
-    - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('updated_at')
+    - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('last_contacted_at')
       = time_tag(last_contact, "#{time_ago_in_words(last_contact)} ago", title: last_contact)
   %td.text-nowrap
     - if project.city.present? && project.state.present?

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -192,7 +192,7 @@
     #project_notes.d-flex.flex-column
       = render @project.project_notes
     #project_note_form
-      = render partial: 'manage/project_notes/form', locals: { project: @project}
+      = render partial: 'manage/project_notes/form', locals: { project: @project }
 
 :javascript
   var updateProjectTimestamp = () => {

--- a/config/initializers/blob_overrides.rb
+++ b/config/initializers/blob_overrides.rb
@@ -2,9 +2,10 @@
 
 Rails.application.config.to_prepare do
   module ActiveStorage::Blob::Representable
-
     # Returns true if the blob is variable or previewable AND it exists in the storage location.
     def representable?
+      return false if ENV["AWS_ACCESS_KEY_ID"].blank?
+
       service.exist?(key) && (variable? || previewable?)
     end
   end

--- a/db/migrate/20250320170812_add_last_contacted_at_to_assignment.rb
+++ b/db/migrate/20250320170812_add_last_contacted_at_to_assignment.rb
@@ -1,0 +1,5 @@
+class AddLastContactedAtToAssignment < ActiveRecord::Migration[8.0]
+  def change
+    add_column :assignments, :last_contacted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_16_160721) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_20_170812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -91,6 +91,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_16_160721) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "status"
+    t.datetime "last_contacted_at"
     t.index ["finisher_id"], name: "index_assignments_on_finisher_id"
     t.index ["project_id"], name: "index_assignments_on_project_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"

--- a/test/controllers/manage/project_notes_controller_test.rb
+++ b/test/controllers/manage/project_notes_controller_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Manage
+  class ProjectNotesControllerTest < ActionController::TestCase
+    setup do
+      @user = users(:admin)
+
+      assert_predicate(@user, :can_manage?)
+      @project = projects(:one)
+    end
+
+    test "can create a note with a description" do
+      sign_in @user
+      post :create, params: { project_id: @project.id, project_note: { description: "This is a note" } },
+                    format: :turbo_stream
+
+      assert_response :success
+      assert_equal(1, @project.project_notes.count)
+      assert_equal("This is a note", @project.project_notes.first.description)
+    end
+
+    test "can create a note and mark as a finisher contact" do
+      assert(@project.active_finisher, "Project must have an active finisher to test this feature")
+      assignment = @project.assignments.where(finisher: @project.active_finisher).first
+
+      assert_predicate(assignment.last_contacted_at, :blank?)
+
+      sign_in @user
+      post :create, params: { project_id: @project.id, project_note: { description: "This is a note" },
+                              finisher_contact: true }, format: :turbo_stream
+
+      assert_response :success
+      assert_predicate(assignment.reload.last_contacted_at, :present?)
+    end
+
+    test "can delete a note" do
+      sign_in @user
+      note = @project.project_notes.create!(user: @user, description: "This is a note")
+
+      assert_equal(1, @project.project_notes.count)
+
+      delete :destroy, params: { project_id: @project.id, id: note.id }, format: :turbo_stream
+
+      assert_response :success
+      assert_equal(0, @project.project_notes.count)
+    end
+  end
+end

--- a/test/fixtures/assignments.yml
+++ b/test/fixtures/assignments.yml
@@ -2,15 +2,16 @@
 #
 # Table name: assignments
 #
-#  id          :bigint           not null, primary key
-#  ended_at    :datetime
-#  started_at  :datetime
-#  status      :text
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  finisher_id :bigint
-#  project_id  :bigint
-#  user_id     :bigint
+#  id                :bigint           not null, primary key
+#  ended_at          :datetime
+#  last_contacted_at :datetime
+#  started_at        :datetime
+#  status            :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  finisher_id       :bigint
+#  project_id        :bigint
+#  user_id           :bigint
 #
 # Indexes
 #

--- a/test/fixtures/assignments.yml
+++ b/test/fixtures/assignments.yml
@@ -24,6 +24,7 @@ knit_active:
   finisher_id: 2
   user_id: 3
   started_at: 2024-01-01
+  status: accepted
 
 knit_inactive:
   project_id: 2

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -2,15 +2,16 @@
 #
 # Table name: assignments
 #
-#  id          :bigint           not null, primary key
-#  ended_at    :datetime
-#  started_at  :datetime
-#  status      :text
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  finisher_id :bigint
-#  project_id  :bigint
-#  user_id     :bigint
+#  id                :bigint           not null, primary key
+#  ended_at          :datetime
+#  last_contacted_at :datetime
+#  started_at        :datetime
+#  status            :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  finisher_id       :bigint
+#  project_id        :bigint
+#  user_id           :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
Add the ability to store the last contact date for an assignment. This will be used to track when the last time a finisher was contacted about a project. Also included here is a checkbox to update the date when adding a project note.

This data may be populated by the auto CC'd emails in the future. At that time we can update this field when the email arrives. I might have held off on this change until email work is completed but it has a few longer term benefits:
  1. Decouples this date tracking from the email work so nobody is blocked (since this was easy)
  2. Updating this at email time will reduce the load of the project management pages since the denormalized value won't require joining to the email date records.
  3. This checkbox will give the manager a way to update if there are out of band contacts as well, which seems likely

## Screenshot

![Notes checkbox](https://github.com/user-attachments/assets/fc7e44eb-ebbd-4076-bffd-1c79096fdccf)

