### PR TITLE
Update mailing address form styling and include in project submitter details

### DIFF
--- a/app/views/application/_submitter_form_fields.html.haml
+++ b/app/views/application/_submitter_form_fields.html.haml
@@ -2,5 +2,7 @@
   .col-md-4
     = form.label :phone_number, 'Your Cell Phone Number', class: 'form-label required'
   .col-md-4
-    = form.text_field :phone_number, class: 'form-control'
+    = form.text_field :phone_number, class: 'form-control', required: true
     .form-info Loose Ends Project may reach out to you via text message.
+
+= render :partial => 'layouts/address_form', :locals => { form: form }

--- a/app/views/layouts/_address_form.html.haml
+++ b/app/views/layouts/_address_form.html.haml
@@ -1,48 +1,64 @@
-#country_ui.row
+.row.mb-4
   .col-md-4
-    = form.label 'Country', class: 'form-label required'
-    = form.select :country, options_for_select(ISO3166::Country.pluck(:iso_short_name, :alpha2).sort_by{|c| I18n.transliterate(c[0])}, form.object.country), { include_blank: true }, { class: 'form-select', onChange: "setStates(this.value)", id: 'country' }
-  .row.my-2
-    .col-12.col-md-10.col-lg-8
-      = form.label 'Street', class: 'form-label required'
-      = form.text_field :street, class: 'form-control'
-  .row.my-2
-    .col-12.col-md-10.col-lg-8
-      = form.label 'Line 2', class: 'form-label optional'
-      = form.text_field :street_2, class: 'form-control'
-  .row.my-2
-    .col-4.col-lg-3
-      = form.label 'City', class: 'form-label required'
-      = form.text_field :city, class: 'form-control'
-    #usState.col-4.col-md-3{ class: ("hidden" unless form.object.country == 'US') }
-      = form.label 'State', class: 'form-label required'
-      = form.select :state, US_STATES, { include_blank: true }, { class: 'form-select' }
-    #caState.col-4.col-md-3{ class: ("hidden" unless form.object.country == 'CA') }
-      = form.label 'Province', class: 'form-label required'
-      = form.select :state, CA_PROVINCES, { include_blank: true }, { class: 'form-select' }
-    #gbState.col-4.col-md-3{ class: ("hidden" unless form.object.country == 'GB') }
-      = form.label 'State', class: 'form-label required'
-      = form.select :state, GB_STATES, { include_blank: true }, { class: 'form-select' }
-    #auState.col-4.col-md-3{ class: ("hidden" unless form.object.country == 'AU') }
-      = form.label 'State', class: 'form-label required'
-      = form.select :state, AU_STATES, { include_blank: true }, { class: 'form-select' }
-    #otState.col-4.col-md-3{ class: ("hidden" if form.object.country.in?(['US', 'CA', 'AU', 'GB']) ) }
-      = form.label 'State/Province', class: 'form-label required'
-      = form.text_field :state, class: 'form-control', id: 'state_ot'
-    .col-4.col-sm-4.col-md-3.col-lg-2
-      = form.label "Postal code", class: 'form-label required'
-      = form.text_field :postal_code, class: 'form-control'
+    = form.label :country, 'Country', class: 'form-label required'
+  .col-md-4
+    = form.select :country, options_for_select(ISO3166::Country.pluck(:iso_short_name, :alpha2).sort_by{|c| I18n.transliterate(c[0])}, form.object.country), { include_blank: true }, { class: 'form-select', onChange: "setStates(this.value)", id: 'country', required: true }
+.row.mb-4
+  .col-md-4
+    = form.label :street, 'Street', class: 'form-label required'
+  .col-md-4
+    = form.text_field :street, class: 'form-control'
+.row.mb-4
+  .col-md-4
+    = form.label :street_2, 'Line 2', class: 'form-label optional'
+  .col-md-4
+    = form.text_field :street_2, class: 'form-control'
+.row.mb-4
+  .col-md-4
+    = form.label :city, 'City', class: 'form-label required'
+  .col-md-4
+    = form.text_field :city, class: 'form-control', required: true
+#usState.row.mb-4{ class: ("hidden" unless form.object.country == 'US') }
+  .col-md-4
+    = form.label 'State', class: 'form-label required'
+  .col-md-4
+    = form.select :state, US_STATES, { include_blank: true }, { class: 'form-select' }
+#caState.row.mb-4{ class: ("hidden" unless form.object.country == 'CA') }
+  .col-md-4
+    = form.label :state, 'Province', class: 'form-label required'
+  .col-md-4
+    = form.select :state, CA_PROVINCES, { include_blank: true }, { class: 'form-select' }
+#gbState.row.mb-4{ class: ("hidden" unless form.object.country == 'GB') }
+  .col-md-4
+    = form.label :state, 'State', class: 'form-label required'
+  .col-md-4
+    = form.select :state, GB_STATES, { include_blank: true }, { class: 'form-select' }
+#auState.row.mb-4{ class: ("hidden" unless form.object.country == 'AU') }
+  .col-md-4
+    = form.label :state, 'State', class: 'form-label required'
+  .col-md-4
+    = form.select :state, AU_STATES, { include_blank: true }, { class: 'form-select' }
+#otState.row.mb-4{ class: ("hidden" if form.object.country.in?(['US', 'CA', 'AU', 'GB'])) }
+  .col-md-4
+    = form.label :state, 'State/Province', class: 'form-label required'
+  .col-md-4
+    = form.text_field :state, class: 'form-control', id: 'state_ot'
+.row.mb-4
+  .col-md-4
+    = form.label :postal_code, "Postal code", class: 'form-label required'
+  .col-md-4
+    = form.text_field :postal_code, class: 'form-control', required: true
 
 :javascript
   const hideState = (stateCode) => {
     const state = document.querySelector('#' + stateCode + 'State')
-    state.style.display = "none"
+    state.classList.add("hidden")
     state.querySelector('select, input').disabled = true;
   }
 
   const showState = (stateCode) => {
     const state = document.querySelector('#' + stateCode + 'State')
-    state.style.display = "block"
+    state.classList.remove("hidden")
     state.querySelector('select, input').disabled = false;
   };
 

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -30,10 +30,6 @@
   %h2 Submitter Details
   %hr
   = render "submitter_form_fields", form: form
-  .my-4
-    %h5 Mailing Address
-    .form-info Where to send it when it's done
-    = render :partial => 'layouts/address_form', :locals => { form: form }
 
   %h2 Original Crafter Details
   %hr

--- a/app/views/projects/_address_form.html.haml
+++ b/app/views/projects/_address_form.html.haml
@@ -2,14 +2,7 @@
   = render "error_messages", resource: @project
   = render 'submitter_form_fields', form: form
 
-  -# The layout & styling is a bit wonky as we're moving to new designs
-  -# TODO: update the address layout with the new 2-col design
-
-  .my-4
-    %h5 Your Mailing Address
-    .form-info After it's finished, we'll send it back here
-    = render :partial => 'layouts/address_form', :locals => { form: form }
   .form-actions
-    = form.submit 'Submit Address', class: "btn btn-primary"
+    = form.submit 'Submit Your Details', class: "btn btn-primary"
     = link_to "Cancel", @project, class: "btn btn-link"
 

--- a/app/views/projects/edit_project.html.haml
+++ b/app/views/projects/edit_project.html.haml
@@ -2,3 +2,6 @@
 = form_with model: @project, html: { class: 'form', data: { turbo: false } } do |form|
   = render "error_messages", resource: @project
   = render 'project_form_fields', form: form
+  .form-actions
+    = form.submit 'Submit Project Details', class: "btn btn-primary"
+    = link_to "Cancel", @project, class: "btn btn-link"

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -7,7 +7,7 @@
   .alert.alert-danger
     Before we can match this project, we need a little more information.  See the messages below.
 .row
-  .col-4.mr-6.row
+  .col-6.mr-6.row
     - @project.project_images.each do |image|
       - if image.representable?
         .removeable_image
@@ -35,7 +35,8 @@
       %p.text-danger
         Tell us about the material.
 
-    = @project.material_type
+    %p 
+      = @project.material_type
     - @project.material_images.each do |image|
       - if image.representable?
         .removeable_image
@@ -56,7 +57,14 @@
       .removeable_file
         = link_to file.blob.filename, url_for(file), { download: true }
         = button_to fa_icon("trash"), project_path(@project, { pattern_file_id: file.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
-  .col-8
+    %h4.mt-4
+      .row
+        .col-9
+          Permissions
+    %p Loose Ends Project has permission to post about my project online, including on social media. #{@project.can_publicize ? fa_icon(:check) : 'No'}
+    %p Loose Ends Project has permission to use my first name in posts online. #{@project.can_use_first_name ? fa_icon(:check) : 'No'}
+
+  .col-6
     %h4
       .row
         .col-9
@@ -65,7 +73,7 @@
           = link_to 'Edit', [:edit_address, :project], class: 'btn btn-link float-end btn-sm'
     .row
       .col-12= @project.phone_number
-    %h4.mt-4
+    %h5.mt-4
       .row
         .col-9
           Mailing Address
@@ -88,7 +96,7 @@
         .col= @project.country
     %hr/
 
-    %h4
+    %h4.mt-4
       .row
         .col-9
           Original Crafter Details
@@ -118,12 +126,4 @@
             %li No Dogs Please
 
     = @project.recipient_name
-    %hr/
-    %h4
-      .row
-        .col-9
-          Permissions
-        .col-3
-          = link_to 'Edit', [:edit_project, @project, anchor: 'permissions'], class: 'btn btn-link float-end btn-sm'
-    %p Loose Ends Project has permission to post about my project online, including on social media. #{@project.can_publicize ? fa_icon(:check) : 'No'}
-    %p Loose Ends Project has permission to use my first name in posts online. #{@project.can_use_first_name ? fa_icon(:check) : 'No'}
+    


### PR DESCRIPTION
This is the last bit required to get the "submit project" form all in a single form instead of requiring additional info after submission.

## Changes
- update address layout to match new 2 col ui
  - in the finishers manage UI, the spacing on this form doesn't match existing spacing but I think that's fine. We're incrementally getting the UI ironed out. 
- add address fields to project submitter form fields
- update project show UI to be slightly cleaner

## Project submission form BEFORE
![screencapture-localhost-3000-projects-new-2025-03-24-18_23_47](https://github.com/user-attachments/assets/5b2cce46-1f82-4e40-b952-4b28c1fb9498)

## Project submission form AFTER
![screencapture-localhost-3000-projects-new-2025-03-24-18_19_17](https://github.com/user-attachments/assets/736923e9-3047-44ad-bc47-49307b95cb92)

## Project show BEFORE
![screencapture-localhost-3000-projects-21-2025-03-24-18_23_25](https://github.com/user-attachments/assets/28a1b3c0-45eb-4c44-8273-56c05d444f50)

## Project show AFTER
![screencapture-localhost-3000-projects-21-2025-03-24-18_19_54](https://github.com/user-attachments/assets/6cce426c-02b0-4bea-8000-5bb8030fb3df)

## Project edit address BEFORE
![screencapture-localhost-3000-projects-21-edit-address-2025-03-24-18_23_11](https://github.com/user-attachments/assets/12e969ed-e9b6-4c7a-b1f5-32f2578b9aaa)

## Project edit address AFTER
![screencapture-localhost-3000-projects-21-edit-address-2025-03-24-18_20_34](https://github.com/user-attachments/assets/272ecaf0-0f8b-4589-bfc1-e41a8cbd89a2)

## Manager edit finisher BEFORE
![screencapture-localhost-3000-manage-finishers-8-edit-2025-03-24-18_22_46](https://github.com/user-attachments/assets/8f745046-0106-4a2f-9f86-cbd417d6c1cf)

## Manager edit finisher AFTER
![screencapture-localhost-3000-manage-finishers-8-edit-2025-03-24-18_21_39](https://github.com/user-attachments/assets/4c41f2e6-82be-4a99-88c3-b83e7159c10c)

