### PR TITLE
Add owner contact info to project csv

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -178,6 +178,14 @@ class Project < ApplicationRecord
     finisher&.name
   end
 
+  def owner_email
+    user&.email
+  end
+
+  def owner_phone
+    user&.phone
+  end
+
   def active_finisher
     assignments.find_by(status: "accepted")&.finisher
   end

--- a/app/views/manage/projects/index.csv.haml
+++ b/app/views/manage/projects/index.csv.haml
@@ -1,4 +1,4 @@
 - fields = %w[id name created_at status description finisher_name city state country owner_email owner_phone]
 = CSV.generate_line(fields.map(&:titleize), row_sep: nil)
 - @projects.includes(finishers: :user).find_each do |project|
-  = CSV.generate_line(fields.map{|attr| project.send(attr.to_sym) }, row_sep: nil)
+  = CSV.generate_line(fields.map{|attr| project.send(attr.to_sym).presence }, row_sep: nil)

--- a/app/views/manage/projects/index.csv.haml
+++ b/app/views/manage/projects/index.csv.haml
@@ -1,4 +1,4 @@
-- fields = %w[id name created_at status description finisher_name city state country]
+- fields = %w[id name created_at status description finisher_name city state country owner_email owner_phone]
 = CSV.generate_line(fields.map(&:titleize), row_sep: nil)
 - @projects.includes(finishers: :user).find_each do |project|
   = CSV.generate_line(fields.map{|attr| project.send(attr.to_sym) }, row_sep: nil)

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -68,7 +68,7 @@ module Manage
 
       assert_response :success
       assert_predicate(response.body, :present?)
-      %w[Id Name].each do |header|
+      ["Id", "Name", "Owner Email", "Owner Phone"].each do |header|
         assert_includes(response.body, header)
       end
     end


### PR DESCRIPTION
When exporting projects to a CSV, the resulting file should include the project owner's contact information: email and phone number

