### PR TITLE
Handle overridden ActiveStorage::Blob.representable? for certain dev environments

### DIFF
--- a/config/initializers/blob_overrides.rb
+++ b/config/initializers/blob_overrides.rb
@@ -3,9 +3,29 @@
 Rails.application.config.to_prepare do
   module ActiveStorage::Blob::Representable
 
-    # Returns true if the blob is variable or previewable AND it exists in the storage location.
+    # Avoid throwing 500s on missing storage objects. The default
+    # representable? doesn't confirm that the object exists on the
+    # storage service before trying to download it.
     def representable?
-      service.exist?(key) && (variable? || previewable?)
+
+      # The blob has to be either variable or previewable, but
+      # we still don't know if it exists on the storage service.
+      return false unless (variable? || previewable?)
+
+      # Sometimes in dev, you might be using a copy of real data
+      # in which case the active_storage_blobs.service_name points to
+      # the live storage service.  If you don't have the storage service
+      # API credentials, you will be frustrated.
+      if Rails.env.development? && (ENV['AWS_ACCESS_KEY_ID'].blank? ||
+          ENV['AWS_SECRET_ACCESS_KEY'].blank?)
+        return true
+      else
+
+        # But, if you do have the storage service credentials,
+        # make sure the object is there before you try to download it.
+        service.exist?(key)
+      end
     end
+
   end
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,11 +13,3 @@ aws_s3:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-2
   bucket: looseendsproject-<%= ENV['RAILS_ENV_DISPLAY'] %>
-
-# Mark's account
-amazon:
-  service: S3
-  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID_MARK'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY_MARK'] %>
-  region: us-west-2
-  bucket: looseends-production


### PR DESCRIPTION
If a developer is using live data in their local db and does not have the live AWS credentials in their .env, they'll get 500s on everything because `representable?` (as modified) tries to reach out to the `active_storage_blobs.service_name` storage service to make sure the object exists before trying to download it.  This mod handles that case.