### PR TITLE
Adding warning when missing address

### DIFF
--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -187,6 +187,9 @@
         = link_to 'Search', [:manage, @project, :finishers, { state: @project.state, country: @project.country }], class: 'btn btn-sm btn-link'
         - if @project.state.present? && @project.country.present?
           = link_to 'Map', [:map, :manage, @project, :finishers, { near: @project.full_address, radius: 50 }], class: 'btn btn-sm btn-link'
+        - else
+          %h5.text-danger
+            Incomplete Address Prevents Map Searching
     = render @project.assignments
     %h4.mt-4 Notes
     #project_note_form


### PR DESCRIPTION
Adding warning when project address is incomplete preventing the mapping function from being used.

Old:
![image](https://github.com/user-attachments/assets/e980b7ad-e336-448e-b5cd-82fcc5ba3e16)


New:
![image](https://github.com/user-attachments/assets/8d490722-2bdf-44a7-b34f-ca370e57a710)
