### PR TITLE
Collection of data clarity issue in project display

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -185,6 +185,11 @@ footer
     i.fa
       color: $gray-400
 
+.assignment-card
+  i.fa
+    color: $secondary
+    width: 1.3rem
+
 // pagination
 .pagination a, .pagination span, .pagination em
   padding: 0.2em 0.5em

--- a/app/views/manage/assignments/_assignment.html.haml
+++ b/app/views/manage/assignments/_assignment.html.haml
@@ -1,4 +1,4 @@
 
 .d-inline-block.border.rounded.p-2
   %turbo-frame{ id: dom_id(assignment) }
-    = render "manage/assignments/assignment_form", assignment: assignment, readonly: local_assigns[:readonly]
+    = render "manage/assignments/assignment_form", assignment: assignment, readonly: local_assigns[:readonly], context: local_assigns[:context]

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -1,11 +1,16 @@
 = form_for [:manage, assignment] do |form|
   %ul.list-unstyled.assignment-card
-    %li
-      = fa_icon("user", title: 'Assigned To')
-      %span= link_to(assignment.finisher.user.name, [ :manage, assignment.finisher ], data: { turbo_frame: :_top })
-    %li
-      = fa_icon("envelope", title: 'Email Address')
-      %span= assignment.finisher.user.email.truncate(25)
+    - if local_assigns[:context] != :project
+      %li
+        = fa_icon("diagram-project", title: 'Assigned To')
+        %span= link_to(assignment.project.name.truncate(25), [ :manage, assignment.project ], data: { turbo_frame: :_top })
+    - if local_assigns[:context] != :finisher
+      %li
+        = fa_icon("user", title: 'Assigned To')
+        %span= link_to(assignment.finisher.user.name.truncate(25), [ :manage, assignment.finisher ], data: { turbo_frame: :_top })
+      %li
+        = fa_icon("envelope", title: 'Email Address')
+        %span= assignment.finisher.user.email.truncate(25)
     %li
       = fa_icon("calendar", title: 'Assigned')
       %span= time_tag(assignment.created_at, "Assigned #{assignment.created_at.to_formatted_s(:short)}", title: assignment.created_at)

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -1,14 +1,29 @@
 = form_for [:manage, assignment] do |form|
-  .pb-2 Assigned to #{link_to(assignment.finisher.user.name, [ :manage, assignment.finisher ], data: { turbo_frame: :_top })} on #{assignment.created_at.to_formatted_s(:short)}
-  .d-inline
-    = form.label 'Finisher Status', class: 'form-label'
-    - if local_assigns[:readonly]
-      %strong
-        = (assignment.status || 'Unknown').titleize
-    - else
-      = form.select :status,  [['Unknown', nil]] + Assignment::STATUS.map{|s| [s.titleize, s] }, {}, { class: 'form-select-sm', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
-    - if assignment.saved_change_to_status?
-      %span.update-flash.visible SAVED
+  %ul.list-unstyled.assignment-card
+    %li
+      = fa_icon("user", title: 'Assigned To')
+      %span= link_to(assignment.finisher.user.name, [ :manage, assignment.finisher ], data: { turbo_frame: :_top })
+    %li
+      = fa_icon("envelope", title: 'Email Address')
+      %span= assignment.finisher.user.email.truncate(25)
+    %li
+      = fa_icon("calendar", title: 'Assigned')
+      %span= time_tag(assignment.created_at, "Assigned #{assignment.created_at.to_formatted_s(:short)}", title: assignment.created_at)
+    - if assignment.created_at != assignment.updated_at
+      %li
+        = fa_icon("calendar-check", title: 'Updated')
+        %span= time_tag(assignment.updated_at, "Updated #{assignment.updated_at.to_formatted_s(:short)}", title: assignment.updated_at)
+    %li
+      = fa_icon("flag", title: 'Status')
+      - if local_assigns[:readonly]
+        %strong
+          = (assignment.status || 'Unknown').titleize
+      - else
+        = form.select :status,  [['Unknown', nil]] + Assignment::STATUS.map{|s| [s.titleize, s] }, {}, { class: 'd-inline form-select form-select-sm w-auto', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
+      - if assignment.saved_change_to_status?
+        %span.update-flash.visible SAVED
+      - else
+        %span.update-flash.opacity-0 SAVED
 
 
 :javascript
@@ -16,6 +31,6 @@
     let visibleFlashSelector = document.querySelector('.update-flash.visible');
     if (visibleFlashSelector) {
       visibleFlashSelector.classList.remove('visible')
-      visibleFlashSelector.classList.add('hidden')
+      visibleFlashSelector.classList.add('opacity-0')
     }
   }, 1000)

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -136,7 +136,7 @@
     %hr/
   .col-3
     %h4 Assignments
-    = render partial: 'manage/assignments/assignment', collection: @finisher.assignments, as: :assignment, locals: { context: :finisher }
+    = render partial: 'manage/assignments/assignment', collection: @finisher.assignments.order(updated_at: :desc), as: :assignment, locals: { context: :finisher }
 
     .page-section
       %h4 Notes

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -136,7 +136,7 @@
     %hr/
   .col-3
     %h4 Assignments
-    = render @finisher.assignments
+    = render partial: 'manage/assignments/assignment', collection: @finisher.assignments, as: :assignment, locals: { context: :finisher }
 
     .page-section
       %h4 Notes

--- a/app/views/manage/projects/_project_card.html.haml
+++ b/app/views/manage/projects/_project_card.html.haml
@@ -8,9 +8,6 @@
       = link_to project.name.truncate(40), [:manage, project]
     %ul.list-unstyled
       %li
-        = fa_icon("pen-to-square", title: 'Last Updated')
-        = time_tag(project.updated_at, "Updated #{time_ago_in_words(project.updated_at)} ago", title: project.updated_at)
-      %li
         = fa_icon("flag", title: 'Status')
         %span= project.status.titleize
       - if project.missing_address_information?
@@ -27,7 +24,7 @@
           %span #{project.active_finisher.name}
         - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('last_contacted_at')
           %li
-            = fa_icon("envelope", title: 'Last Contact')
+            = fa_icon("envelope", title: 'Last Finisher Response')
             = time_tag(last_contact, "Contact #{time_ago_in_words(last_contact)} ago", title: last_contact)
       - elsif project.assignments.any?
         %li
@@ -40,7 +37,7 @@
             %span #{project.assignments.count} inactive finishers
           %li
             - last_contact = project.assignments.maximum(:updated_at)
-            = fa_icon("envelope", title: 'Last Contact')
+            = fa_icon("envelope", title: 'Last Finisher Response')
             - if last_contact.present?
               = time_tag(last_contact, "Contact #{time_ago_in_words(last_contact)} ago", title: last_contact)
             - else
@@ -50,5 +47,5 @@
           = fa_icon("user", title: 'Finishers')
           %span No Finishers
         %li.missing
-          = fa_icon("envelope", title: 'Last Contact')
+          = fa_icon("envelope", title: 'Last Finisher Response')
           %span N/A

--- a/app/views/manage/projects/_project_row.html.haml
+++ b/app/views/manage/projects/_project_row.html.haml
@@ -1,7 +1,6 @@
 %tr
   %td.text-nowrap= link_to project.name.truncate(40), [:manage, project]
   %td.text-nowrap= project.status.titleize
-  %td.text-nowrap= time_tag(project.updated_at, "#{time_ago_in_words(project.updated_at)} ago", title: project.updated_at)
   %td.text-nowrap
     - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('last_contacted_at')
       = time_tag(last_contact, "#{time_ago_in_words(last_contact)} ago", title: last_contact)

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -9,11 +9,10 @@
   - if params[:view] == 'list'
     %table.table.project-table
       %thead
-        %tr
+        %tr.small
           %th.sortable{ data: { sort: "name asc", reverse: "name desc" } } Project Name
           %th.sortable{ data: { sort: "status asc", reverse: "status desc" } } Status
-          %th.sortable{ data: { sort: "updated_at asc", reverse: "updated_at desc" } } Last Updated
-          %th Last Contacted
+          %th.text-nowrap Last Finisher Response
           %th.sortable{ data: { sort: "users.email asc", reverse: "users.email desc" } } Project Owner
           %th.sortable{ data: { sort: "finishers.chosen_name asc nulls last", reverse: "finishers.chosen_name desc nulls last" } } Finisher
       %tbody

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -190,7 +190,7 @@
         - else
           %h5.text-danger
             Incomplete Address Prevents Map Searching
-    = render partial: 'manage/assignments/assignment', collection: @project.assignments, as: :assignment, locals: { context: :project }
+    = render partial: 'manage/assignments/assignment', collection: @project.assignments.order(updated_at: :desc), as: :assignment, locals: { context: :project }
     %h4.mt-4 Notes
     #project_note_form
       = render partial: 'manage/project_notes/form', locals: { project: @project }

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -190,7 +190,7 @@
         - else
           %h5.text-danger
             Incomplete Address Prevents Map Searching
-    = render @project.assignments
+    = render partial: 'manage/assignments/assignment', collection: @project.assignments, as: :assignment, locals: { context: :project }
     %h4.mt-4 Notes
     #project_note_form
       = render partial: 'manage/project_notes/form', locals: { project: @project }

--- a/test/controllers/manage/assignments_controller_test.rb
+++ b/test/controllers/manage/assignments_controller_test.rb
@@ -31,7 +31,7 @@ module Manage
       patch :update, params: { id: assignment.id, assignment: { status: "invited" } }, format: :turbo_stream
 
       assert_response :success
-      assert_match(/SAVED/, response.body)
+      assert_select(".update-flash.visible", count: 1)
     end
 
     test "turbo stream update renders NO saved label if nothing changed" do
@@ -40,7 +40,7 @@ module Manage
       patch :update, params: { id: assignment.id, assignment: { status: "invited" } }, format: :turbo_stream
 
       assert_response :success
-      assert_no_match(/SAVED/, response.body)
+      assert_select(".update-flash.visible", count: 0)
     end
   end
 end


### PR DESCRIPTION
There were a few small items related to project display I bundled up into a single PR:

1. Project list: [Rename 'Last Contacted' to 'Last Finisher Response'](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08LCC527GQ)
2. Project list/card: [Remove 'Last Updated'](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08LMTYJWCQ)
3. [Add Finisher email to assignment card](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08KN37S3DK)
4. [Assignment card on Finisher page should link to Project instead of Finisher](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08KHRWE0G6)

## Screenshots

### Project List updates (1 & 2)
![New project list](https://github.com/user-attachments/assets/c336887c-baac-42d4-a38b-34e1120f410e)

### Assignment Card Updates (3 & 4)

Reformatted for clarity. Made link at top contextual. Showing side by side of the card from Project page (left) and Finisher page (right)

![Assignment cards](https://github.com/user-attachments/assets/376e6316-140d-41e4-bfc3-28f8bbe591bc)


