### PR TITLE
Add Project Status Test (hidden by default)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -83,7 +83,8 @@ class Project < ApplicationRecord
     "on hold",
     "will not do",
     "waiting for return to rematch",
-    "weird circumstance"
+    "weird circumstance",
+    "test"
   ].freeze
 
   READY_TO_MATCH_STATUSES = [
@@ -154,6 +155,8 @@ class Project < ApplicationRecord
   after_validation :geocode, if: lambda { |obj|
     obj.full_address.present? && obj.full_address_has_changed?
   }
+
+  scope :ignore_tests, -> { where.not(status: "test") }
 
   before_save :clear_ready_status_unless_ready_to_match
   before_save :clear_in_process_status_unless_in_process

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -192,6 +192,14 @@ module Manage
       assert_search_no_results(status: "drafted")
     end
 
+    test "search without status ignores status=test" do
+      result = create_search_project
+      result.update!(status: "test")
+
+      assert_search_no_results({})
+      assert_search_results([result], status: "test")
+    end
+
     test "search by assigned" do
       result = create_search_project
       result.assignments.create!(user: @user, finisher: Finisher.first)


### PR DESCRIPTION
Add a new Project status of "test". These are excluded from the Project search/list page unless you specifically search for status=test. This should accomplish to goal of [hiding the distracting test projects](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08KA3SN7TR) while letting integration work continue. If we fell they are still a distraction or a problem we can revisit adding a Project delete function.