### PR TITLE
Update language on T&C checkbox for clarity

### DIFF
--- a/app/views/manage/finishers/_form.html.haml
+++ b/app/views/manage/finishers/_form.html.haml
@@ -10,7 +10,7 @@
     .col-3
       = form.label :approved do
         = form.check_box :approved
-        Approved
+        Finisher Terms and Conditions Accepted
   .row.mb-2
     = form.label :chosen_name, class: 'col-2 col-form-label'
     .col-4


### PR DESCRIPTION
For improvement item to [add field for finisher terms and conditions accepted](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08G3AUKT6Z)

Just ended up being some wording changes. Per Jen kept checkboxes together/didn't move above emergency contact like item description