### PR TITLE
Display email instead of name for project list view

### DIFF
--- a/app/views/manage/projects/_project_row.html.haml
+++ b/app/views/manage/projects/_project_row.html.haml
@@ -7,8 +7,8 @@
   %td.text-nowrap= link_to project.user.email, [:admin, project.user]
   %td.text-nowrap
     - if project.active_finisher.present? && assignment = project.assignments.where(finisher: project.active_finisher).first
-      = link_to project.active_finisher&.name, [:manage, project.active_finisher]
+      = link_to project.active_finisher&.user&.email, [:manage, project.active_finisher]
       %span.ms-1.badge.rounded-pill.text-bg-primary= assignment.status
     - elsif project.finisher.present? && assignment = project.assignments.where(finisher: project.finisher).first
-      = link_to project.finisher&.name, [:manage, project.finisher]
+      = link_to project.finisher&.user&.email, [:manage, project.finisher]
       %span.badge.rounded-pill.text-bg-secondary= assignment.status


### PR DESCRIPTION
Per a Slack request from Jen the finisher email is much more helpful than the name in the contact of Project search list views:


![Project list view with email instead of name](https://github.com/user-attachments/assets/2a9277de-c380-4f4f-8f63-324380f601d1)
