### PR TITLE
Add a reusable copy-to-clipboard component

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -196,10 +196,13 @@ footer
   &:after
     font-family: "Font Awesome 6 Free"
     content: "\f328"
+    title: "Copy to Clipboard"
+    cursor: pointer
     padding-left: 0.5rem
     display: inline-block
 
   &.copied
+    font-weight: normal
     font-size: 0.8rem
     background: $yellow-100
     padding: 0.5rem

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -190,6 +190,21 @@ footer
     color: $secondary
     width: 1.3rem
 
+// Copy Helper
+
+.copy-supported
+  &:after
+    font-family: "Font Awesome 6 Free"
+    content: "\f328"
+    padding-left: 0.5rem
+    display: inline-block
+
+  &.copied
+    font-size: 0.8rem
+    background: $yellow-100
+    padding: 0.5rem
+    border-radius: 0.5rem
+
 // pagination
 .pagination a, .pagination span, .pagination em
   padding: 0.2em 0.5em

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+const CopyDelayMs = 1000
+
+export default class extends Controller {
+  connect() {
+    if ("clipboard" in navigator) {
+      this.element.classList.add("copy-supported")
+      this.element.setAttribute("aria-label", "Copy to clipboard")
+      this.element.addEventListener("click", this.copy.bind(this))
+    }
+  }
+
+  copy(event) {
+    let textForCopy = this.element.textContent
+    event.preventDefault()
+    navigator.clipboard.writeText(textForCopy)
+    this.element.classList.add("copied")
+    this.element.textContent = "Copied!"
+
+    setTimeout(() => {
+      this.element.classList.remove("copied")
+      this.element.textContent
+       = textForCopy
+    }, CopyDelayMs)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,5 +7,8 @@ import { application } from "./application"
 import AutocompleteController from "./autocomplete_controller"
 application.register("autocomplete", AutocompleteController)
 
+import ClipboardController from "./clipboard_controller"
+application.register("clipboard", ClipboardController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -31,7 +31,7 @@
 
     .page-section.mb-2
       %b Email:
-      = @finisher.user.email
+      %span{ data: { controller: 'clipboard' } }= @finisher.user.email
     .page-section.mb-2
       %b Phone Number:
       = @finisher.phone_number

--- a/app/views/messages/_index.html.haml
+++ b/app/views/messages/_index.html.haml
@@ -5,9 +5,8 @@
     .mb-3
       %span To attach an email to this #{resource.class}, send to
       %span
-        %b
+        %b{ data: { controller: 'clipboard' } }
           %a#email_address(href="mailto:#{resource.inbound_email_address}") #{resource.inbound_email_address}
-        %i(class="fa-regular fa-clipboard" data-toggle="tooltip" data-placement="top" title="Copy to clipboard"onclick="copyToClipboard()")
 
 - if resource.messages.any?
   .d-flex.flex-column
@@ -28,9 +27,3 @@
             %td= link_to message.email.subject, message
             %td
               // TODO action buttons (view, delete)
-
-:javascript
-  function copyToClipboard() {
-    var anchor = document.getElementById("email_address");
-    navigator.clipboard.writeText(anchor.text);
-  }


### PR DESCRIPTION
This is one of the things reusable Stimulus controllers are really good at so I used that. The Stimulus frameworky bits will handle hooking this up to the page elements during load or `turbo:load` as needed. The crux is that any element with `data-controller="clipboard"` will get the little clipboard icon appended and support click-to-copy with the associated feedback (see below).

I convert one existing copy to clipboard use and added a new one for finisher profile email addresses. This feels like a feature managers will want in more places once it's available.

## Copy in action

![Click to copy example](https://github.com/user-attachments/assets/2de5f958-8632-44fa-99dc-86ecc715d726)
