### PR TITLE
Fix email link host on staging

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,3 +1,6 @@
+// GMail CSS guide: https://developers.google.com/workspace/gmail/design/css
+// Check https://github.com/fphilipe/premailer-rails
+
 !!!
 %html{xmlns: "http://www.w3.org/1999/xhtml", "xml:lang" => "en-US", lang: "en-US"}
   %head
@@ -11,7 +14,7 @@
         display: inline-block;
         padding: 10px 20px;
         background-color: #007bff;
-        color: #fff;
+        color: #ffffff;
         text-decoration: none;
         border-radius: 5px;
         font-weight: bold;

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   #
-  host = ENV["RAILS_ENV_DISPLAY"] == "production" ? "app" : "app-staging"
+  host = ENV.fetch("RAILS_ENV_DISPLAY", "") == "production" ? "app" : "app-staging"
   config.action_mailer.default_url_options =
     { host: "#{host}.looseendsproject.org", protocol: "https" }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,7 +66,10 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "app.looseendsproject.org", protocol: "https" }
+  #
+  host = ENV["RAILS_ENV_DISPLAY"] == "production" ? "app" : "app-staging"
+  config.action_mailer.default_url_options =
+    { host: "#{host}.looseendsproject.org", protocol: "https" }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {

--- a/test/controllers/users/passwords_controller_test.rb
+++ b/test/controllers/users/passwords_controller_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class Users::PasswordsControllerTest < ActionDispatch::IntegrationTest
   test 'create sends reset instructions' do
     post '/users/password', params: { user: { email: User.last.email } }
-    assert_response :redirect
+    assert_redirected_to "/users/sign_in"
     assert_equal "Reset password instructions", ActionMailer::Base.deliveries.last.subject
     assert_equal [User.last.email], ActionMailer::Base.deliveries.last.to
   end


### PR DESCRIPTION
config/production.rb was setting the destination host as production for emails sent from staging