### PR TITLE
Add craft type to project overview

### DIFF
--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -122,7 +122,12 @@
           Has Smoke In Home
     - if @project.no_smoke || @project.no_cats || @project.no_dogs || (@project.in_home_pets.present? && @project.in_home_pets.select(&:present?).any?) || @project.has_smoke_in_home
       %hr/
-    %h4 Material Details
+
+    %h4 Craft Type
+    = @project.craft_type
+
+    %h4.mt-4
+      Material Details
     .row
       %b.col-auto Type:
       .col


### PR DESCRIPTION
Craft type now appears on project overview page - no longer need to go into edit mode to view craft type

Improvement item: [Make the craft field visible on the project page (when not in edit mode)](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08MJBVSGQG)

Screenshot:
![image](https://github.com/user-attachments/assets/b0ce5140-22e4-45a1-b486-e87bf131d5bb)
