### PR TITLE
Hotfix: PDF pattern files + login redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-
   def test_flash_messages
     flash.alert = "Careful here! (:alert)"
     flash.notice = "Nice work! (:notice)"
@@ -18,8 +17,10 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource_or_scope)
-    stored_location_for(resource_or_scope) && return
+    stored_location = stored_location_for(resource_or_scope)
+    return stored_location if stored_location.present?
     return manage_dashboard_path if resource&.can_manage?
+
     root_path
   end
 

--- a/app/controllers/finishers_controller.rb
+++ b/app/controllers/finishers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FinishersController < AuthenticatedController
-  before_action :store_user_location!, if: :storable_location?
+  prepend_before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!, except: [:show]
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < AuthenticatedController
-  before_action :store_user_location!, if: :storable_location?
+  prepend_before_action :store_user_location!, if: :storable_location?
 
   before_action :get_project, only: %i[
     show

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -151,8 +151,11 @@
       Is there a pattern? #{@project.has_pattern}
     - @project.pattern_files.each do |file|
       .removeable_file
-        = link_to image_tag(file.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
-        url_for(file.variant(format: :jpg)), target: "_blank"
+        - if file.variable?
+          = link_to image_tag(file.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
+          url_for(file.variant(format: :jpg)), target: "_blank"
+        - else
+          = link_to(file.filename, url_for(file))
         = button_to fa_icon("trash"), project_path(@project, { pattern_file_id: file.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
     %h4 Original Crafter Details
     - if @project.crafter_name? || @project.crafter_description? || @project.crafter_images.any?

--- a/test/integration/user_access_test.rb
+++ b/test/integration/user_access_test.rb
@@ -1,26 +1,48 @@
-require 'test_helper'
+require "test_helper"
 
 class UserAccessTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test 'landing page loads' do
-    get '/'
+  test "landing page loads" do
+    get "/"
+
     assert_response :success
   end
 
-  test 'user/registration loads' do
-    get '/users/sign_up'
+  test "user/registration loads" do
+    get "/users/sign_up"
+
     assert_response :success
   end
 
-  test '/finisher for unauthed request redirects' do
-    get '/finisher'
+  test "/finisher for unauthed request redirects" do
+    get "/finisher"
+
     assert_redirected_to new_user_session_path
   end
 
   test "finisher can view profile" do
     sign_in users(:finisher)
-    get '/finisher'
+    get "/finisher"
+
     assert_response :success
+  end
+
+  test "Sign in redirect from project redirects back" do
+    project = projects(:one)
+    user = project.user
+    user.password = "password"
+    user.save!
+    get "/projects/#{project.id}"
+
+    assert_redirected_to new_user_session_path
+    follow_redirect!
+
+    assert_response :success
+    assert_select "h1", { text: "Sign in" }
+
+    post "/users/sign_in", params: { user: { email: user.email, password: "password" } }
+
+    assert_redirected_to "/projects/#{project.id}"
   end
 end


### PR DESCRIPTION
Fix an issue with PDF pattern files. This change uses `file.variable?` to guard attempting to generate a variant URL. If the file cannot generate a variant (like a PDF) we show the file name instead.

Also fixed here was an issue where logins with a return path set in the Devise cookie were throwing a 500. There was a logic flaw in `&& return` causing a nil return value. A unit test was added to confirm. The `before_filter` used to set return paths needed to be prepended to return before authentication in the test.

Fixes: [Can't transform blob with ID=? and content_type=application/pdf](https://heroku-cfc27630.airbrake.io/projects/519044/groups/4049059313744366905?tab=overview)
Fixes: [ ActionController::ActionControllerError:  Cannot redirect to nil! ](https://heroku-cfc27630.airbrake.io/projects/519044/groups/4048927268481289520?tab=overview)