### PR TITLE
HOTFIX InboundEmails

### DIFF
--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -2,14 +2,6 @@
 
 namespace :backfill do
 
-  desc "Set inbound_email_address on Project where NULL"
-  task inbound_emails: [:environment] do |_t|
-    Project.where('inbound_email_address IS NULL').all.each do |p|
-      puts p.ensure_inbound_email_address
-      p.save!(validate: false)
-    end
-  end
-
   desc "Set message.channel"
   task message_channel: [:environment] do |_t|
     Message.where('channel IS NULL').update_all(channel: 'inbound')
@@ -44,17 +36,6 @@ namespace :backfill do
   task needs_attention: [:environment] do |_t|
     Note.where(sentiment: "not_great").each do |note|
       note.notable.project.update!(needs_attention: "negative_sentiment")
-    end
-  end
-
-  desc "Downcase inbound_email_addresses"
-  task downcase_inbound_email: [:environment] do |_t|
-    Finisher.where.not(inbound_email_address: nil).map do |f|
-      f.update_attribute("inbound_email_address", f.inbound_email_address.downcase)
-    end
-
-    Project.where.not(inbound_email_address: nil).map do |p|
-      p.update_attribute("inbound_email_address", p.inbound_email_address.downcase)
     end
   end
 

--- a/test/fixtures/finishers.yml
+++ b/test/fixtures/finishers.yml
@@ -59,7 +59,7 @@ crocheter:
   chosen_name: Bobby
   description: I love to crochet.
   phone_number: 1234567890
-  inbound_email_address: Finisher-AskQeXbS@localhost
+  inbound_email_address: finisher-askqexbs@localhost
 
 knitter:
   id: 2

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -82,7 +82,7 @@ one:
   postal_code: 12345
   country: USA
   manager_id: 3
-  inbound_email_address: Project-7A37voRf@localhost
+  inbound_email_address: project-7a37vorf@localhost
   created_at: <%= 8.days.ago %>
   updated_at: <%= 7.days.ago %>
 
@@ -94,6 +94,6 @@ two:
   status: ready to match
   phone_number: 1234567890
   craft_type: knitting
-  inbound_email_address: Project-t4Tzy9NI@localhost
+  inbound_email_address: project-t4tzy9ni@localhost
   created_at: <%= 3.days.ago %>
   updated_at: <%= 2.days.ago %>

--- a/test/mailboxes/forwards_mailbox_test.rb
+++ b/test/mailboxes/forwards_mailbox_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 class ForwardsMailboxTest < ActionMailbox::TestCase
 
+  # Originally, addresses had upper/lower and were downcased
+  # in the database.  Preserve this for backwards testing
+  # of old addresses
+  #
   PROJECT_ADDRESS = 'Project-7A37voRf@localhost'
   FINISHER_ADDRESS = 'Finisher-AskQeXbS@localhost'
 
@@ -17,7 +21,7 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     assert_equal 'pending', @inbound.status
   end
 
-  test 'project found' do
+  test 'project found in to: array #first' do
     assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
 
     # Test was throwing a pg transaction error, but this works...
@@ -29,7 +33,30 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     end
   end
 
-  test 'finisher found' do
+  test "project found in to: array not #first" do
+    @inbound.mail.to = ["random@example.com", PROJECT_ADDRESS]
+
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Project.find(1).messages.last.content.body.to_s
+      refute Project.find(2).messages.any?
+    end
+  end
+
+  test 'finisher downcased found' do
+    @inbound.mail.to = FINISHER_ADDRESS.downcase
+    assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
+
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Finisher.find(1).messages.last.content.body.to_s
+      refute Finisher.find(2).messages.any?
+    end
+  end
+
+  test 'finisher original case found' do
     @inbound.mail.to = FINISHER_ADDRESS
     assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
 
@@ -47,4 +74,5 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
       assert_raises(ActiveRecord::RecordNotFound) { @inbound.route }
     end
   end
+
 end


### PR DESCRIPTION
Two email fixes:
- handle downcase and mixed case inbound_email_addresses
- handle where inbound_email_address is not first in the to: array
- rake task to reprocess failed InboundEmails