### PR TITLE
Correct a couple of Airbrake template errors

### DIFF
--- a/app/views/manage/assignments/new.html.haml
+++ b/app/views/manage/assignments/new.html.haml
@@ -1,2 +1,2 @@
-%h1 Assign <strong>#{@project.name}</strong> to <strong>#{@finisher.user.name}</strong>?
+%h1 Assign <strong>#{@project.name}</strong> to <strong>#{@finisher.name}</strong>?
 = render 'form'

--- a/app/views/projects/_crafter_form_fields.html.haml
+++ b/app/views/projects/_crafter_form_fields.html.haml
@@ -14,7 +14,8 @@
   .col-md-4
     = form.file_field :append_crafter_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
     - form.object.crafter_images.each do |image|
-      = image_tag image.representation( resize_to_limit: [100, 100])
+      - if image.variable?
+        = image_tag image.representation( resize_to_limit: [100, 100])
     .form-info Please upload photos of the crafter, if you have them.
 .row.mb-4
   .col-md-4


### PR DESCRIPTION
This fixes a couple of template errors reported in Airbrake:

1. [ActionView::Template::Error:  Cannot get a signed_id for a new record](https://heroku-cfc27630.airbrake.io/projects/519044/groups/4050722068062817633?tab=overview). This was an error showing the Project creating page after a create failed to validate (edge case). I added a `variable?` check to the display so we don't call `image.representation` when it cannot succeed.
2. [ActionView::Template::Error: undefined method name for nil](https://heroku-cfc27630.airbrake.io/projects/519044/groups/4051258116673129858?tab=overview). This calls `finisher.name` instead of `finisher.user.name` though when I checked the Finisher, Project, and User all exist. I doubt this fixes it but it narrows it down f it happens again.