### PR TITLE
Update can_share_crafter_details to true by default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-
   def test_flash_messages
     flash.alert = "Careful here! (:alert)"
     flash.notice = "Nice work! (:notice)"
@@ -18,8 +17,10 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource_or_scope)
-    stored_location_for(resource_or_scope) && return
+    stored_location = stored_location_for(resource_or_scope)
+    return stored_location if stored_location.present?
     return manage_dashboard_path if resource&.can_manage?
+
     root_path
   end
 

--- a/app/controllers/finishers_controller.rb
+++ b/app/controllers/finishers_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FinishersController < AuthenticatedController
-  before_action :store_user_location!, if: :storable_location?
+  prepend_before_action :store_user_location!, if: :storable_location?
   before_action :authenticate_user!, except: [:show]
 
   def show

--- a/app/controllers/manage/inbound_emails_controller.rb
+++ b/app/controllers/manage/inbound_emails_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Manage
+  class InboundEmailsController < Manage::ManageController
+
+    # GET /manage/inbound_emails
+    def index
+      @inbound_emails = ActionMailbox::InboundEmail.all
+    end
+
+  end
+end

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -95,6 +95,7 @@ module Manage
         :has_pattern,
         :material_type,
         :material_brand,
+        :has_materials,
         :crafter_name,
         :crafter_description,
         :crafter_dominant_hand,

--- a/app/controllers/message_controller.rb
+++ b/app/controllers/message_controller.rb
@@ -7,7 +7,7 @@ class MessageController < AuthenticatedController
     @message = Message.find(params[:id])
 
     # TODO allow regular user to see his/her own messages
-    if current_user.admin? || current_user.manager?
+    if current_user.can_manage?
       render 'messages/show'
     else
       raise ActiveRecord::RecordNotFound

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProjectsController < AuthenticatedController
-  before_action :store_user_location!, if: :storable_location?
+  prepend_before_action :store_user_location!, if: :storable_location?
 
   before_action :get_project, only: %i[
     show

--- a/app/mailboxes/forwards_mailbox.rb
+++ b/app/mailboxes/forwards_mailbox.rb
@@ -9,11 +9,12 @@ class ForwardsMailbox < ApplicationMailbox
   private
 
   def resource
-    mail.to.each do |to|
-      matches = /^(\w+)-\w{#{EmailAddressable::LENGTH}}@/.match(to)
+    all_addresses = [mail.to, mail.cc, mail.bcc].flatten.compact
+    all_addresses.each do |addr|
+      matches = /^(\w+)-\w{#{EmailAddressable::LENGTH}}@/.match(addr)
       if matches.present?
         klass = matches[1].titleize.constantize
-        record = klass.find_by(inbound_email_address: to.downcase)
+        record = klass.find_by(inbound_email_address: addr.downcase)
         return record if record.present?
       end
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -58,7 +58,7 @@ class Message < ApplicationRecord
   end
 
   def email
-    Mail.from_source content.to_plain_text
+    Mail.from_source Mail::Encodings::QuotedPrintable.decode(content.to_plain_text)
   end
   alias_method :mail, :email
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,7 +6,7 @@
 #
 #  id                        :bigint           not null, primary key
 #  can_publicize             :boolean
-#  can_share_crafter_details :boolean          default(FALSE)
+#  can_share_crafter_details :boolean          default(TRUE)
 #  can_use_first_name        :boolean          default(FALSE)
 #  city                      :string
 #  country                   :string

--- a/app/views/manage/assignments/new.html.haml
+++ b/app/views/manage/assignments/new.html.haml
@@ -1,2 +1,2 @@
-%h1 Assign <strong>#{@project.name}</strong> to <strong>#{@finisher.user.name}</strong>?
+%h1 Assign <strong>#{@project.name}</strong> to <strong>#{@finisher.name}</strong>?
 = render 'form'

--- a/app/views/manage/dashboards/_mail_traffic_dashboard.html.haml
+++ b/app/views/manage/dashboards/_mail_traffic_dashboard.html.haml
@@ -1,16 +1,16 @@
 - window = params[:window] && params[:window].to_i > 0 ? params[:window]&.to_i : 3 # days
 - since = (Time.zone.now - window.days).beginning_of_day
 
+- limit = 10 # HACK temporary performance hack
+
 %hr
-%h3 New email from last #{window} days
+%h3 New email from last #{window} days, most recent #{limit}
 
 .row.pt-3
   .col
-    / - messages = Message.inbound.since(since)
-    / - if messages.any?
-    /   .pt-1= render partial: 'messages/compact',
-    /     locals: { format: 'inbound', messages:  messages }
-    / - else
-    /   %p.fst-italic No new email since #{since.to_formatted_s(:human)} (try refreshing)
-
-    .fst-italic Temporarily removed for performance reasons.  Fix underway
+    - messages = Message.with_rich_text_content.includes(:messageable).inbound.since(since).limit(limit).order(created_at: :desc)
+    - if messages.any?
+      .pt-1= render partial: 'messages/compact',
+        locals: { format: 'inbound', messages:  messages }
+    - else
+      %p.fst-italic No new email since #{since.to_formatted_s(:human)} (try refreshing)

--- a/app/views/manage/dashboards/_mail_traffic_dashboard.html.haml
+++ b/app/views/manage/dashboards/_mail_traffic_dashboard.html.haml
@@ -6,9 +6,11 @@
 
 .row.pt-3
   .col
-    - messages = Message.inbound.since(since)
-    - if messages.any?
-      .pt-1= render partial: 'messages/compact',
-        locals: { format: 'inbound', messages:  messages }
-    - else
-      %p.fst-italic No new email since #{since.to_formatted_s(:human)} (try refreshing)
+    / - messages = Message.inbound.since(since)
+    / - if messages.any?
+    /   .pt-1= render partial: 'messages/compact',
+    /     locals: { format: 'inbound', messages:  messages }
+    / - else
+    /   %p.fst-italic No new email since #{since.to_formatted_s(:human)} (try refreshing)
+
+    .fst-italic Temporarily removed for performance reasons.  Fix underway

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -40,8 +40,8 @@
   .row.pt-3
     .col
       = render partial: "job_logs_dashboard"
-      = link_to 'Manage queues', 'jobs'
-
+      .pt-0= link_to 'Manage queues', 'jobs'
+      .pt-0= link_to "Inbound Emails", "inbound_emails#index"
 
   - if Rails.env.development?
     = render partial: 'email_previews'

--- a/app/views/manage/inbound_emails/index.html.haml
+++ b/app/views/manage/inbound_emails/index.html.haml
@@ -1,0 +1,20 @@
+%h1 Failed Inbound Emails
+
+%table.table.table-sm
+  %thead
+    %tr
+      %th Created At
+      %th Addresses
+      %th Subject
+      %th Status
+  %tbody
+    - @inbound_emails.failed.each do |inbound|
+      %tr
+        %td= inbound.created_at.to_formatted_s(:human)
+        %td
+          .pt-0 From: #{inbound.mail.from}
+          .pt-0 To: #{inbound.mail.to}
+          .pt-0 CC: #{inbound.mail.cc}
+        %td= inbound.mail.subject
+        %td= inbound.status
+

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -151,8 +151,11 @@
       Is there a pattern? #{@project.has_pattern}
     - @project.pattern_files.each do |file|
       .removeable_file
-        = link_to image_tag(file.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
-        url_for(file.variant(format: :jpg)), target: "_blank"
+        - if file.variable?
+          = link_to image_tag(file.representation( resize_to_limit: [100, 100]), class: 'thumbnail'), |
+          url_for(file.variant(format: :jpg)), target: "_blank"
+        - else
+          = link_to(file.filename, url_for(file))
         = button_to fa_icon("trash"), project_path(@project, { pattern_file_id: file.id }), method: :delete, :onclick => "return confirm('Are you sure?')", class: 'icon'
     %h4 Original Crafter Details
     - if @project.crafter_name? || @project.crafter_description? || @project.crafter_images.any?

--- a/app/views/messages/show.html.haml
+++ b/app/views/messages/show.html.haml
@@ -21,10 +21,15 @@
     %p.pt-0
       %pre= @message.email.text_part.body.to_s
 
-  - if @message.email.html_part.present?
-    %p.pt-3.fw-bold HTML Part
-    %p.pt-0= sanitize @message.email.html_part.body.to_s
-    %hr
+  / HACK temporary until encoding issue is resolved
+  / - if @message.email.html_part.present?
+  /   %p.pt-3.fw-bold HTML Part
+  /   %p.pt-0= sanitize @message.email.html_part.body.to_s
+
+  %p.pt-3.fw-bold Raw Source
+  %pre= @message.email.raw_source
+
+  %hr
 
   .row
     - @message.email.attachments.each do |attachment|

--- a/app/views/projects/_crafter_form_fields.html.haml
+++ b/app/views/projects/_crafter_form_fields.html.haml
@@ -14,7 +14,8 @@
   .col-md-4
     = form.file_field :append_crafter_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
     - form.object.crafter_images.each do |image|
-      = image_tag image.representation( resize_to_limit: [100, 100])
+      - if image.variable?
+        = image_tag image.representation( resize_to_limit: [100, 100])
     .form-info Please upload photos of the crafter, if you have them.
 .row.mb-4
   .col-md-4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       get "card", on: :member
     end
     resources :job_logs, only: [:show]
+    resources :inbound_emails
     get "reports/heard_about_us", to: "reports#heard_about_us"
   end
 

--- a/db/migrate/20250203180045_add_can_share_crafter_details_to_projects.rb
+++ b/db/migrate/20250203180045_add_can_share_crafter_details_to_projects.rb
@@ -1,5 +1,5 @@
 class AddCanShareCrafterDetailsToProjects < ActiveRecord::Migration[7.0]
   def change
-    add_column :projects, :can_share_crafter_details, :boolean, default: false
+    add_column :projects, :can_share_crafter_details, :boolean, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,7 +235,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_192708) do
     t.string "press_region"
     t.string "press_outlet"
     t.boolean "can_use_first_name", default: false
-    t.boolean "can_share_crafter_details", default: false
+    t.boolean "can_share_crafter_details", default: true
     t.string "has_materials"
     t.text "material_brand"
     t.string "inbound_email_address"

--- a/lib/tasks/backfill.rake
+++ b/lib/tasks/backfill.rake
@@ -2,14 +2,6 @@
 
 namespace :backfill do
 
-  desc "Set inbound_email_address on Project where NULL"
-  task inbound_emails: [:environment] do |_t|
-    Project.where('inbound_email_address IS NULL').all.each do |p|
-      puts p.ensure_inbound_email_address
-      p.save!(validate: false)
-    end
-  end
-
   desc "Set message.channel"
   task message_channel: [:environment] do |_t|
     Message.where('channel IS NULL').update_all(channel: 'inbound')
@@ -44,17 +36,6 @@ namespace :backfill do
   task needs_attention: [:environment] do |_t|
     Note.where(sentiment: "not_great").each do |note|
       note.notable.project.update!(needs_attention: "negative_sentiment")
-    end
-  end
-
-  desc "Downcase inbound_email_addresses"
-  task downcase_inbound_email: [:environment] do |_t|
-    Finisher.where.not(inbound_email_address: nil).map do |f|
-      f.update_attribute("inbound_email_address", f.inbound_email_address.downcase)
-    end
-
-    Project.where.not(inbound_email_address: nil).map do |p|
-      p.update_attribute("inbound_email_address", p.inbound_email_address.downcase)
     end
   end
 

--- a/lib/tasks/blobs.rake
+++ b/lib/tasks/blobs.rake
@@ -38,4 +38,5 @@ namespace :blobs do
     blob = ActiveStorage::Blob.where(service_name: source_service.name).first
     CopyBlobJob.perform_later(blob, source_service.name, destination_service.name)
   end
+
 end

--- a/test/controllers/manage/inbound_emails_controller_test.rb
+++ b/test/controllers/manage/inbound_emails_controller_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Manage
+  class InboundEmailsControllerTest < ActionDispatch::IntegrationTest
+    def setup
+      sign_in(users(:admin))
+    end
+
+    test "index" do
+      get "/manage/inbound_emails"
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -108,7 +108,8 @@ module Manage
       @project.name = "New Name"
 
       sign_in @user
-      patch "/manage/projects/#{@project.id}", params: { project: { name: "New Name" } }
+      assert_nil @project.has_materials
+      patch "/manage/projects/#{@project.id}", params: { project: { name: "New Name" }}
 
       assert_redirected_to manage_project_path(@project)
       assert_equal("New Name", @project.reload.name)
@@ -124,10 +125,15 @@ module Manage
 
     test "update updates material brand" do
       sign_in @user
-      patch "/manage/projects/#{@project.id}", params: { project: { material_brand: "brandname" } }
+      patch "/manage/projects/#{@project.id}", params: { project: {
+        material_brand: "brandname",
+        has_materials: "Yes",
+        append_material_images: [file_fixture_upload("test.jpg", "image/jpeg")]
+      }}
 
       assert_redirected_to manage_project_path(@project)
       assert_equal("brandname", @project.reload.material_brand)
+      assert_equal("Yes", @project.has_materials)
     end
 
     test "create with incomplete params renders page" do

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MessagesControllerTest < ActionDispatch::IntegrationTest
+
+  def setup
+    sign_in users(:admin)
+  end
+
+  test "render HTML UTF-8 content" do
+    get "/message/1"
+    assert_response :success
+  end
+end

--- a/test/fixtures/finishers.yml
+++ b/test/fixtures/finishers.yml
@@ -59,7 +59,7 @@ crocheter:
   chosen_name: Bobby
   description: I love to crochet.
   phone_number: 1234567890
-  inbound_email_address: Finisher-AskQeXbS@localhost
+  inbound_email_address: finisher-askqexbs@localhost
 
 knitter:
   id: 2

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -4,7 +4,7 @@
 #
 #  id                        :bigint           not null, primary key
 #  can_publicize             :boolean
-#  can_share_crafter_details :boolean          default(FALSE)
+#  can_share_crafter_details :boolean          default(TRUE)
 #  can_use_first_name        :boolean          default(FALSE)
 #  city                      :string
 #  country                   :string

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -82,7 +82,7 @@ one:
   postal_code: 12345
   country: USA
   manager_id: 3
-  inbound_email_address: Project-7A37voRf@localhost
+  inbound_email_address: project-7a37vorf@localhost
   created_at: <%= 8.days.ago %>
   updated_at: <%= 7.days.ago %>
 
@@ -94,6 +94,6 @@ two:
   status: ready to match
   phone_number: 1234567890
   craft_type: knitting
-  inbound_email_address: Project-t4Tzy9NI@localhost
+  inbound_email_address: project-t4tzy9ni@localhost
   created_at: <%= 3.days.ago %>
   updated_at: <%= 2.days.ago %>

--- a/test/integration/user_access_test.rb
+++ b/test/integration/user_access_test.rb
@@ -1,26 +1,48 @@
-require 'test_helper'
+require "test_helper"
 
 class UserAccessTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test 'landing page loads' do
-    get '/'
+  test "landing page loads" do
+    get "/"
+
     assert_response :success
   end
 
-  test 'user/registration loads' do
-    get '/users/sign_up'
+  test "user/registration loads" do
+    get "/users/sign_up"
+
     assert_response :success
   end
 
-  test '/finisher for unauthed request redirects' do
-    get '/finisher'
+  test "/finisher for unauthed request redirects" do
+    get "/finisher"
+
     assert_redirected_to new_user_session_path
   end
 
   test "finisher can view profile" do
     sign_in users(:finisher)
-    get '/finisher'
+    get "/finisher"
+
     assert_response :success
+  end
+
+  test "Sign in redirect from project redirects back" do
+    project = projects(:one)
+    user = project.user
+    user.password = "password"
+    user.save!
+    get "/projects/#{project.id}"
+
+    assert_redirected_to new_user_session_path
+    follow_redirect!
+
+    assert_response :success
+    assert_select "h1", { text: "Sign in" }
+
+    post "/users/sign_in", params: { user: { email: user.email, password: "password" } }
+
+    assert_redirected_to "/projects/#{project.id}"
   end
 end

--- a/test/mailboxes/forwards_mailbox_test.rb
+++ b/test/mailboxes/forwards_mailbox_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 class ForwardsMailboxTest < ActionMailbox::TestCase
 
+  # Originally, addresses had upper/lower and were downcased
+  # in the database.  Preserve this for backwards testing
+  # of old addresses
+  #
   PROJECT_ADDRESS = 'Project-7A37voRf@localhost'
   FINISHER_ADDRESS = 'Finisher-AskQeXbS@localhost'
 
@@ -17,7 +21,7 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     assert_equal 'pending', @inbound.status
   end
 
-  test 'project found' do
+  test 'project found in to: array #first' do
     assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
 
     # Test was throwing a pg transaction error, but this works...
@@ -29,7 +33,30 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
     end
   end
 
-  test 'finisher found' do
+  test "project found in to: array not #first" do
+    @inbound.mail.to = ["random@example.com", PROJECT_ADDRESS]
+
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Project.find(1).messages.last.content.body.to_s
+      refute Project.find(2).messages.any?
+    end
+  end
+
+  test 'finisher downcased found' do
+    @inbound.mail.to = FINISHER_ADDRESS.downcase
+    assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
+
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Finisher.find(1).messages.last.content.body.to_s
+      refute Finisher.find(2).messages.any?
+    end
+  end
+
+  test 'finisher original case found' do
     @inbound.mail.to = FINISHER_ADDRESS
     assert_equal ForwardsMailbox, ApplicationMailbox.mailbox_for(@inbound)
 
@@ -47,4 +74,5 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
       assert_raises(ActiveRecord::RecordNotFound) { @inbound.route }
     end
   end
+
 end

--- a/test/mailboxes/forwards_mailbox_test.rb
+++ b/test/mailboxes/forwards_mailbox_test.rb
@@ -35,7 +35,26 @@ class ForwardsMailboxTest < ActionMailbox::TestCase
 
   test "project found in to: array not #first" do
     @inbound.mail.to = ["random@example.com", PROJECT_ADDRESS]
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Project.find(1).messages.last.content.body.to_s
+      refute Project.find(2).messages.any?
+    end
+  end
 
+  test "project found in cc:" do
+    @inbound.mail.cc = ["random@example.com", PROJECT_ADDRESS]
+    ActiveRecord::Base.transaction do
+      @inbound.route
+      assert_match /Subject: Getting started with ActiveMailbox/,
+        Project.find(1).messages.last.content.body.to_s
+      refute Project.find(2).messages.any?
+    end
+  end
+
+  test "project found in bcc:" do
+    @inbound.mail.bcc = ["random@example.com", PROJECT_ADDRESS]
     ActiveRecord::Base.transaction do
       @inbound.route
       assert_match /Subject: Getting started with ActiveMailbox/,

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -103,8 +103,13 @@ class MessageTest < ActiveSupport::TestCase
     m.save!
 
     assert_predicate m.email, :multipart?
+    assert_equal m.email.html_part.content_type, "text/html; charset=UTF-8"
+    assert_equal m.email.html_part.content_transfer_encoding, "quoted-printable"
+
     assert_equal ["inbound@example.com"], m.email.to
-    # TODO: assert_equal 'forwarder@example.com', m.email.from
+
+    # HACK temporary
+    # assert_equal 'forwarder@example.com', m.email.from
     assert_equal "Fwd: Test inbound from Gmail", m.email.subject
     assert_equal "2025-03-22T12:25:35-04:00", m.email.date.to_s
     assert_match(/How does this look\?/, m.email.text_part.body.decoded)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -6,7 +6,7 @@
 #
 #  id                        :bigint           not null, primary key
 #  can_publicize             :boolean
-#  can_share_crafter_details :boolean          default(FALSE)
+#  can_share_crafter_details :boolean          default(TRUE)
 #  can_use_first_name        :boolean          default(FALSE)
 #  city                      :string
 #  country                   :string


### PR DESCRIPTION
Improvement: [Make sharing original crafter details an opt-out instead of opt-in](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08LG46AQNB)

Instead of switching opt-out to opt-in, made the checkbox checked by default on project submission