### PR TITLE
Simplify Project status

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -174,6 +174,9 @@ footer
 
 // Project management
 
+h1.project-name
+  margin-bottom: .25em
+
 .project-table
   .sortable
     cursor: pointer
@@ -207,6 +210,10 @@ footer
 #needs-attention-container
   #needs-attention-select
     color: $danger
+    font-weight: bold
+
+#project-status-container
+  #project-status-select
     font-weight: bold
 
 .assignment-card

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -72,7 +72,7 @@ module Manage
     def status_options_for_select
       status_counts = Project.group(:status).count
 
-      Project::STATUSES.map do |status|
+      Project::STATUSES.values.map do |status|
         ["#{status}#{status_counts[status].to_i.positive? ?
           " (#{status_counts[status]})" : ''}", status ]
       end

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -12,7 +12,7 @@ module Manage
         format.csv { add_csv_headers }
         format.html do
           @projects = @projects.paginate(page: params[:page], per_page: params[:per_page])
-          @status_counts = status_counts
+          @status_options_for_select = status_options_for_select
         end
       end
     end
@@ -69,10 +69,13 @@ module Manage
         "attachment; filename=#{@title.parameterize}-#{DateTime.now.strftime("%Y-%m-%d-%H%M")}.csv"
     end
 
-    def status_counts
+    def status_options_for_select
       status_counts = Project.group(:status).count
-      status_counts.merge!(Project.group(:ready_status).count)
-      status_counts.merge!(Project.group(:in_process_status).count)
+
+      Project::STATUSES.map do |status|
+        ["#{status}#{status_counts[status].to_i.positive? ?
+          " (#{status_counts[status]})" : ''}", status ]
+      end
     end
 
     def project_params
@@ -83,8 +86,6 @@ module Manage
         :description,
         :more_details,
         :status,
-        :ready_status,
-        :in_process_status,
         :street,
         :street_2,
         :city,

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -44,11 +44,12 @@ class Assignment < ApplicationRecord
   end
 
   def self.needs_check_in
-    active.where("
-      status = ?
+    active.joins(:project).where("
+      assignments.status = ?
+      AND projects.status = ?
       AND (last_contacted_at < ? OR last_contacted_at IS NULL)
       AND (check_in_sent_at < ? OR check_in_sent_at IS NULL)
-      ", "accepted", CHECK_IN_INTERVAL.ago, CHECK_IN_INTERVAL.ago)
+      ", "accepted", "IN PROCESS: UNDERWAY", CHECK_IN_INTERVAL.ago, CHECK_IN_INTERVAL.ago)
   end
 
   def name

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -23,7 +23,6 @@
 #  index_assignments_on_project_id   (project_id)
 #
 class Assignment < ApplicationRecord
-  # STATUS = %w[potential invited accepted declined unresponsive completed].freeze
   STATUSES = {
     potential: "potential",
     invited: "invited",
@@ -31,7 +30,7 @@ class Assignment < ApplicationRecord
     declined: "declined",
     unresponsive: "unresponsive",
     completed: "completed"
-  }
+  }.freeze
   CHECK_IN_INTERVAL = 2.weeks
 
   belongs_to :project, touch: true

--- a/app/models/concerns/loose_ends_searchable.rb
+++ b/app/models/concerns/loose_ends_searchable.rb
@@ -230,15 +230,6 @@ module LooseEndsSearchable
                else
                  with_field_value(result, :status, params[:status])
                end
-      result = with_sub_status(result, :ready_status, params) \
-        if params[:status] == "ready to match"
-      result = with_sub_status(result, :in_process_status, params) \
-        if params[:status] == "in process"
-      result
-    end
-
-    def with_sub_status(query, field, params)
-      with_field_value(query, field, params[field])
     end
 
     def with_manager_id(query, manager_id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -69,26 +69,26 @@
 #  fk_rails_...  (manager_id => users.id)
 #
 class Project < ApplicationRecord
-  STATUSES = [
-    "PROPOSED",
-    "WAITING PROJECT CONFIRMATION",
-    "READY TO MATCH: NEW",
-    "READY TO MATCH: ADDITIONAL ATTEMPT",
-    "READY TO MATCH: NEEDS SECOND SKILL",
-    "READY TO MATCH: REMATCH REQUESTED",
-    "FINISHER INVITED",
-    "ACCEPTED WAITING TERMS",
-    "INTRODUCED",
-    "IN PROCESS: CONNECTED",
-    "IN PROCESS: WAITING HANDOFF",
-    "IN PROCESS: UNDERWAY",
-    "IN PROCESS: PO UNRESPONSIVE",
-    "FINISHED NOT RETURNED",
-    "DONE",
-    "ON HOLD",
-    "WILL NOT DO",
-    "TEST"
-  ].freeze
+  STATUSES = {
+    proposed: "PROPOSED",
+    waiting_for_project_confirmation: "WAITING PROJECT CONFIRMATION",
+    ready_to_match_new: "READY TO MATCH: NEW",
+    ready_to_match_additional_attempt: "READY TO MATCH: ADDITIONAL ATTEMPT",
+    ready_to_match_needs_second_skill: "READY TO MATCH: NEEDS SECOND SKILL",
+    ready_to_match_rematch_requested: "READY TO MATCH: REMATCH REQUESTED",
+    finisher_invited: "FINISHER INVITED",
+    accepted_waiting_terms: "ACCEPTED WAITING TERMS",
+    introduced: "INTRODUCED",
+    in_process_connected: "IN PROCESS: CONNECTED",
+    in_process_waiting_handoff: "IN PROCESS: WAITING HANDOFF",
+    in_process_underway: "IN PROCESS: UNDERWAY",
+    in_process_po_unresponsive: "IN PROCESS: PO UNRESPONSIVE",
+    finished_not_returned: "FINISHED NOT RETURNED",
+    done: "DONE",
+    on_hold: "ON HOLD",
+    will_not_do: "WILL NOT DO",
+    test: "TEST"
+  }.freeze
 
   BOOLEAN_ATTRIBUTES = %i[joann_helped urgent influencer group_project press privacy_needed].freeze
 
@@ -120,7 +120,7 @@ class Project < ApplicationRecord
 
   before_validation :set_default_status
 
-  validates :status, inclusion: { in: STATUSES }
+  validates :status, inclusion: { in: STATUSES.values }
   validates :status, presence: true
   validates :needs_attention, inclusion: {
     in: NEEDS_ATTENTION_REASONS, allow_blank: true, allow_nil: true }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("DRAFTED"), not null
+#  status                    :string           default("PROPOSED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean
@@ -70,7 +70,6 @@
 #
 class Project < ApplicationRecord
   STATUSES = [
-    "DRAFTED",
     "PROPOSED",
     "WAITING PROJECT CONFIRMATION",
     "READY TO MATCH: NEW",
@@ -86,7 +85,6 @@ class Project < ApplicationRecord
     "IN PROCESS: PO UNRESPONSIVE",
     "FINISHED NOT RETURNED",
     "DONE",
-    "PO UNRESPONSIVE",
     "ON HOLD",
     "WILL NOT DO",
     "TEST"
@@ -155,16 +153,8 @@ class Project < ApplicationRecord
   scope :ignore_tests, -> { where.not(status: "test") }
   scope :needing_attention, -> { where.not(needs_attention: nil).order(name: :asc) }
 
-  after_update :move_to_proposed
-
-  def move_to_proposed
-    return unless !missing_information? && status == "DRAFTED"
-
-    update_column(:status, "PROPOSED")
-  end
-
   def set_default_status
-    self.status ||= "DRAFTED"
+    self.status ||= "PROPOSED"
   end
 
   def finisher

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -70,39 +70,26 @@
 #
 class Project < ApplicationRecord
   STATUSES = [
-    "drafted",
-    "proposed",
-    "submitted via google",
-    "project confirm email sent",
-    "ready to match",
-    "finisher invited",
-    "project accepted/waiting on terms",
-    "introduced",
-    "in process",
-    "finished/not returned",
-    "done",
-    "unresponsive",
-    "on hold",
-    "will not do",
-    "waiting for return to rematch",
-    "weird circumstance",
-    "test"
-  ].freeze
-
-  READY_TO_MATCH_STATUSES = [
-    "new",
-    "new - additional attempt",
-    "new - needs to go on facebook",
-    "old - needs match with a second skill",
-    "old - finisher requested rematch"
-  ].freeze
-
-  IN_PROCESS_STATUSES = [
-    "connected (both finisher and po have responded)",
-    "po still has project",
-    "humming along",
-    "check in",
-    "po out of touch"
+    "DRAFTED",
+    "PROPOSED",
+    "WAITING PROJECT CONFIRMATION",
+    "READY TO MATCH: NEW",
+    "READY TO MATCH: ADDITIONAL ATTEMPT",
+    "READY TO MATCH: NEEDS SECOND SKILL",
+    "READY TO MATCH: REMATCH REQUESTED",
+    "FINISHER INVITED",
+    "ACCEPTED WAITING TERMS",
+    "INTRODUCED",
+    "IN PROCESS: CONNECTED",
+    "IN PROCESS: WAITING HANDOFF",
+    "IN PROCESS: UNDERWAY",
+    "IN PROCESS: PO UNRESPONSIVE",
+    "FINISHED NOT RETURNED",
+    "DONE",
+    "PO UNRESPONSIVE",
+    "ON HOLD",
+    "WILL NOT DO",
+    "TEST"
   ].freeze
 
   BOOLEAN_ATTRIBUTES = %i[joann_helped urgent influencer group_project press privacy_needed].freeze
@@ -168,19 +155,16 @@ class Project < ApplicationRecord
   scope :ignore_tests, -> { where.not(status: "test") }
   scope :needing_attention, -> { where.not(needs_attention: nil).order(name: :asc) }
 
-  before_save :clear_ready_status_unless_ready_to_match
-  before_save :clear_in_process_status_unless_in_process
-
   after_update :move_to_proposed
 
   def move_to_proposed
-    return unless !missing_information? && status == "drafted"
+    return unless !missing_information? && status == "DRAFTED"
 
-    update_column(:status, "proposed")
+    update_column(:status, "PROPOSED")
   end
 
   def set_default_status
-    self.status ||= "drafted"
+    self.status ||= "DRAFTED"
   end
 
   def finisher
@@ -208,11 +192,7 @@ class Project < ApplicationRecord
   end
 
   def self.proposed
-    where({ status: "proposed" })
-  end
-
-  def self.submitted_via_google
-    where({ status: "submitted via google" })
+    where({ status: "PROPOSED" })
   end
 
   def self.project_confirm_email_sent
@@ -341,15 +321,5 @@ class Project < ApplicationRecord
 
   def has_materials?
     has_materials == 'Yes'
-  end
-
-  private
-
-  def clear_ready_status_unless_ready_to_match
-    self.ready_status = nil unless status == "ready to match"
-  end
-
-  def clear_in_process_status_unless_in_process
-    self.in_process_status = nil unless status == "in process"
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("drafted"), not null
+#  status                    :string           default("DRAFTED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean
@@ -189,74 +189,6 @@ class Project < ApplicationRecord
 
   def active_finisher
     active_assignment&.finisher
-  end
-
-  def self.proposed
-    where({ status: "PROPOSED" })
-  end
-
-  def self.project_confirm_email_sent
-    where({ status: "project confirm email sent" })
-  end
-
-  def self.ready_to_match
-    where({ status: "ready to match" })
-  end
-
-  def self.finisher_invited
-    where({ status: "finisher invited" })
-  end
-
-  def self.project_accepted_waiting_on_terms
-    where({ status: "project accepted/waiting on terms" })
-  end
-
-  def self.introduced
-    where({ status: "introduced" })
-  end
-
-  def self.in_process
-    where({ status: "in process" })
-  end
-
-  def self.finished
-    where({ status: "finished/not returned" })
-  end
-
-  def self.done
-    where({ status: "done" })
-  end
-
-  def self.unresponsive
-    where({ status: "unresponsive" })
-  end
-
-  def self.on_hold
-    where({ status: "on hold" })
-  end
-
-  def self.will_not_do
-    where({ status: "will not do" })
-  end
-
-  def self.waiting_for_return_to_rematch
-    where({ status: "waiting for return to rematch" })
-  end
-
-  def self.weird_circumstance
-    where({ status: "weird circumstance" })
-  end
-
-  def self.has_status(status_state)
-    where({ status: status_state })
-  end
-
-  def self.has_ready_status(status)
-    where(ready_status: status)
-  end
-
-  def self.has_in_process_status(status)
-    where(in_process_status: status)
   end
 
   def self.has_assigned(assigned_state)

--- a/app/views/manage/assignment_updates/_assignment_update.html.haml
+++ b/app/views/manage/assignment_updates/_assignment_update.html.haml
@@ -1,5 +1,0 @@
-%turbo-frame{ id: dom_id(assignment_update)}
-  %p
-    = assignment_update.description
-    = assignment_update.created_at
-    = assignment_update.user.name

--- a/app/views/manage/assignment_updates/create.html.haml
+++ b/app/views/manage/assignment_updates/create.html.haml
@@ -1,2 +1,0 @@
-\%h1 Manage::AssignmentUpdates#create
-\%p Find me in app/views/manage/assignment_updates/create.html.haml

--- a/app/views/manage/assignment_updates/destroy.html.haml
+++ b/app/views/manage/assignment_updates/destroy.html.haml
@@ -1,2 +1,0 @@
-\%h1 Manage::AssignmentUpdates#destroy
-\%p Find me in app/views/manage/assignment_updates/destroy.html.haml

--- a/app/views/manage/assignment_updates/new.html.haml
+++ b/app/views/manage/assignment_updates/new.html.haml
@@ -1,2 +1,0 @@
-\%h1 Manage::AssignmentUpdates#new
-\%p Find me in app/views/manage/assignment_updates/new.html.erb

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -24,7 +24,7 @@
         %strong
           = (assignment.status || 'Unknown').titleize
       - else
-        = form.select :status,  [['Unknown', nil]] + Assignment::STATUS.map{|s| [s.titleize, s] }, {}, { class: 'd-inline form-select form-select-sm w-auto', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
+        = form.select :status,  [['Unknown', nil]] + Assignment::STATUSES.values.map{|s| [s.titleize, s] }, {}, { class: 'd-inline form-select form-select-sm w-auto', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
       - if assignment.saved_change_to_status?
         %span.update-flash.visible SAVED
       - else

--- a/app/views/manage/assignments/_form.html.haml
+++ b/app/views/manage/assignments/_form.html.haml
@@ -11,5 +11,5 @@
   - if !@finisher.assigned_to(@project)
     .form-actions.border-top.pt-4
       = form.label :status, 'Assignment Status'
-      = form.select :status,  [['Unknown', nil]] + Assignment::STATUS.map{|s| [s.titleize, s] }, {}, { class: 'form-select-sm me-4', autocomplete: 'off' }
+      = form.select :status,  [['Unknown', nil]] + Assignment::STATUSES.values.map{|s| [s.titleize, s] }, {}, { class: 'form-select-sm me-4', autocomplete: 'off' }
       = form.submit 'Assign Project', class: "btn btn-primary"

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -18,12 +18,7 @@
   .row
     .col-2
       = link_to 'Projects', manage_projects_path
-    .col-2
-      Proposed: #{Project.proposed.count + Project.submitted_via_google.count}
-    .col-2
-      In Progress: #{Project.on_hold.count + Project.project_confirm_email_sent.count + Project.ready_to_match.count + Project.finisher_invited.count + Project.project_accepted_waiting_on_terms.count + Project.introduced.count + Project.in_process.count + Project.will_not_do.count + Project.unresponsive.count + Project.waiting_for_return_to_rematch.count + Project.weird_circumstance.count}
-    .col-2
-      Done: #{Project.done.count}
+    .col-6.fst-italic Numbers removed pending redesign
 
   .row.pt-3
     .col

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -2,27 +2,20 @@
   = render "error_messages", resource: @project
 
   .row.justify-content-between.align-items-center
-    %h2.col-6 Project Details
-    .col-6.row
+    %h2.col-4 Project Details
+    .col-8.row
       .d-flex.align-items-end
-        .col-5.me-2
+        .col-8.me-2
           = form.label :status, class: 'form-label'
-          = form.select :status, Project::STATUSES.map { |status| [status.humanize, status] }, { }, { id: 'status-dropdown', class: 'form-select' }
-        .col-5.me-2
+          = form.select :status, Project::STATUSES.map { |status| [status, status] }, { }, { id: 'status-dropdown', class: 'form-select' }
+        .col-3.me-2
           = form.label :manager_id, class: 'form-label'
           = form.select :manager_id, User.project_managers.map { |a| [a.name, a.id] }, { include_blank: true }, { class: 'form-select' }
         .col-2
           - if current_user.admin?
             = link_to 'Cancel', [:manage, @project], class: 'btn btn-danger float-end'
           -# This section will be toggled based on the selected status
-      .mt-2#ready-status-row{ class: [@project.status == 'ready to match' ? 'd-flex' : 'd-none'] }
-        .col-5.me-2
-          = form.label :ready_status, 'Ready to Match Status', class: 'form-label'
-          = form.select :ready_status, Project::READY_TO_MATCH_STATUSES.map { |status| [status.humanize, status] }, { include_blank: true }, { class: 'form-select' }
-      .mt-2#in-process-status-row{ class:[@project.status == 'in process' ? 'd-flex' : 'd-none'] }
-        .col-5.me-2
-          = form.label :in_process_status, 'In Process Status', class: 'form-label'
-          = form.select :in_process_status, Project::IN_PROCESS_STATUSES.map { |status| [status.humanize.gsub(/\bpo\b/i, 'PO'), status] }, { include_blank: true }, { class: 'form-select' }
+
   %hr
 
   .page-section

--- a/app/views/manage/projects/_form.html.haml
+++ b/app/views/manage/projects/_form.html.haml
@@ -7,7 +7,7 @@
       .d-flex.align-items-end
         .col-8.me-2
           = form.label :status, class: 'form-label'
-          = form.select :status, Project::STATUSES.map { |status| [status, status] }, { }, { id: 'status-dropdown', class: 'form-select' }
+          = form.select :status, Project::STATUSES.values.map { |status| [status, status] }, { }, { id: 'status-dropdown', class: 'form-select' }
         .col-3.me-2
           = form.label :manager_id, class: 'form-label'
           = form.select :manager_id, User.project_managers.map { |a| [a.name, a.id] }, { include_blank: true }, { class: 'form-select' }

--- a/app/views/manage/projects/_project_card.html.haml
+++ b/app/views/manage/projects/_project_card.html.haml
@@ -9,7 +9,7 @@
     %ul.list-unstyled
       %li
         = fa_icon("flag", title: 'Status')
-        %span= project.status.titleize
+        %span= project.status
       - if project.missing_address_information?
         %li.missing
           = fa_icon("location-dot", title: 'Location')

--- a/app/views/manage/projects/_project_status_form.html.haml
+++ b/app/views/manage/projects/_project_status_form.html.haml
@@ -1,0 +1,19 @@
+= form_with model: project, url: manage_project_path(project),
+    html: { id: "project-status-form", class: "form", data: { turbo_frame: "project-status-frame" } } do |form|
+  = form.select :status, options_for_select(Project::STATUSES, project.status),
+    { include_blank: false },
+    { id: "project-status-select", class: "form-select", autocomplete: 'off',
+      onchange: 'this.form.requestSubmit()' }
+  - if project.saved_change_to_status?
+    %span.update-flash.visible SAVED
+  - else
+    %span.update-flash.opacity-0 SAVED
+
+:javascript
+  setTimeout(() => {
+    let visibleFlashSelector = document.querySelector('.update-flash.visible');
+    if (visibleFlashSelector) {
+      visibleFlashSelector.classList.remove('visible')
+      visibleFlashSelector.classList.add('opacity-0')
+    }
+  }, 1000)

--- a/app/views/manage/projects/_project_status_form.html.haml
+++ b/app/views/manage/projects/_project_status_form.html.haml
@@ -1,6 +1,6 @@
 = form_with model: project, url: manage_project_path(project),
     html: { id: "project-status-form", class: "form", data: { turbo_frame: "project-status-frame" } } do |form|
-  = form.select :status, options_for_select(Project::STATUSES, project.status),
+  = form.select :status, options_for_select(Project::STATUSES.values, project.status),
     { include_blank: false },
     { id: "project-status-select", class: "form-select", autocomplete: 'off',
       onchange: 'this.form.requestSubmit()' }

--- a/app/views/manage/projects/_search.html.haml
+++ b/app/views/manage/projects/_search.html.haml
@@ -38,12 +38,3 @@
       = button_tag(formaction: manage_projects_path(format: 'csv'), class: 'btn btn-sm btn-light ms-2') do
         %span export csv
         = fa_icon('file-export')
-
-  .row#ready-status-row{ style: "display: none;" }
-    .col-4
-      = label_tag :ready_status, 'Ready to Match Status:', class: 'form-label'
-      = select_tag :ready_status, options_for_select(Project::READY_TO_MATCH_STATUSES.map { |status| ["#{status.humanize}#{@status_counts[status].to_i.positive? ? " (#{@status_counts[status]})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'
-  .row#in-process-status-row{ style: "display: none;" }
-    .col-4
-      = label_tag :in_process_status, 'In Process Status:', class: 'form-label'
-      = select_tag :in_process_status, options_for_select(Project::IN_PROCESS_STATUSES.map { |status| ["#{status.humanize.gsub(/\bpo\b/i, 'PO')}#{@status_counts[status].to_i.positive? ? " (#{@status_counts[status]})" : ''}", status] }, params[:ready_status]), include_blank: true, class: 'form-select'

--- a/app/views/manage/projects/_search.html.haml
+++ b/app/views/manage/projects/_search.html.haml
@@ -17,7 +17,7 @@
       Per Page:
   .row.mb-2
     .col
-      = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status}#{@status_counts[status].to_i.positive? ? " (#{@status_counts[status]})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
+      = select_tag :status, options_for_select(@status_options_for_select, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
     .col
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
     .col

--- a/app/views/manage/projects/_search.html.haml
+++ b/app/views/manage/projects/_search.html.haml
@@ -17,7 +17,7 @@
       Per Page:
   .row.mb-2
     .col
-      = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status.humanize}#{@status_counts[status].to_i.positive? ? " (#{@status_counts[status]})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
+      = select_tag :status, options_for_select(Project::STATUSES.map{ |status| ["#{status}#{@status_counts[status].to_i.positive? ? " (#{@status_counts[status]})" : ''}", status ]}, params[:status]), include_blank: true, id: 'status-dropdown', class: 'form-select'
     .col
       = select_tag :assigned, options_for_select([['True', 'true'], ['False', 'false']], params[:assigned]), include_blank: true, class: 'form-select'
     .col

--- a/app/views/manage/projects/_status.html.haml
+++ b/app/views/manage/projects/_status.html.haml
@@ -1,0 +1,4 @@
+- if current_user.admin?
+  #project-status-container
+    = turbo_frame_tag "project-status-frame" do
+      = render "manage/projects/project_status_form", project: project, readonly: local_assigns[:readonly], context: local_assigns[:context]

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -44,36 +44,6 @@
     sortFormElem.form.requestSubmit()
   };
 
-  var updateStatus = (newStatus) => {
-    const readyStatusRow = document.getElementById('ready-status-row');
-    const inProcessStatusRow = document.getElementById('in-process-status-row');
-
-    if (newStatus === 'ready to match') {
-      readyStatusRow.style.display = 'block';
-      inProcessStatusRow.style.display = 'none';
-    } else if (newStatus === 'in process') {
-      readyStatusRow.style.display = 'none';
-      inProcessStatusRow.style.display = 'block';
-    } else {
-      readyStatusRow.style.display = 'none';
-      inProcessStatusRow.style.display = 'none';
-    }
-  }
-
-  var setupStatusDropdown = () => {
-    const statusElement = document.getElementById('status-dropdown');
-    if (!statusElement) {
-      return;
-    }
-
-    // Update with dropdown state on page load.
-    updateStatus(statusElement.value);
-    statusElement.addEventListener('change', () => {
-      // Update when changed after page load.
-      updateStatus(statusElement.value);
-    });
-  };
-
   var setupSortHeaders = () => {
     const currentSort = document.getElementById('sort').value
     const sortableHeaders = document.getElementsByClassName('sortable')
@@ -93,7 +63,6 @@
   };
 
   var setupDomListeners = () => {
-    setupStatusDropdown()
     setupSortHeaders()
   };
 

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -10,7 +10,7 @@
 
 %hr
 
-- if current_user.can_manage? || current_user == @project.user
+- if current_user.can_manage?
   = link_to 'Edit', [:edit, :manage, @project], class: 'btn btn-outline-secondary float-end'
 
 .row

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -1,16 +1,17 @@
 = hidden_field_tag "updated_at_utc", @project.updated_at.iso8601
 %small#updated_at= "Last updated:"
-%h1
-  = @project.name
-  - if current_user.admin?
-    - if @project.status == 'ready to match' && @project.ready_status.present?
-      (#{@project.status.humanize} - #{@project.ready_status.humanize})
-    - elsif @project.status == 'in process' && @project.in_process_status.present?
-      (#{@project.status.humanize} - #{@project.in_process_status.humanize.gsub(/\bpo\b/i, 'PO')})
-    - else
-      (#{@project.status.humanize})
-  - if current_user.can_manage? || current_user == @project.user
-    = link_to 'Edit', [:edit, :manage, @project], class: 'btn btn-outline-secondary float-end'
+
+.row
+  .col
+    .float-start
+      %h1.project-name= @project.name
+    .float-end
+      = render partial: "status", locals: { project: @project }
+
+%hr
+
+- if current_user.can_manage? || current_user == @project.user
+  = link_to 'Edit', [:edit, :manage, @project], class: 'btn btn-outline-secondary float-end'
 
 .row
   .col-4

--- a/app/views/manage/projects/update.turbo_stream.haml
+++ b/app/views/manage/projects/update.turbo_stream.haml
@@ -1,2 +1,5 @@
 = turbo_stream.replace "needs-attention-form" do
   = render "needs_attention_form", project: @project
+
+= turbo_stream.replace "project-status-form" do
+  = render "project_status_form", project: @project

--- a/db/migrate/20250418183845_update_default_status.rb
+++ b/db/migrate/20250418183845_update_default_status.rb
@@ -1,0 +1,5 @@
+class UpdateDefaultStatus < ActiveRecord::Migration[8.0]
+  def change
+    change_column :projects, :status, :string, null: false, default: "DRAFTED"
+  end
+end

--- a/db/migrate/20250422115749_change_default_status.rb
+++ b/db/migrate/20250422115749_change_default_status.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultStatus < ActiveRecord::Migration[8.0]
+  def change
+    change_column :projects, :status, :string, null: false, default: "PROPOSED"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_15_192708) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_18_183845) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -193,7 +193,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_192708) do
 
   create_table "projects", force: :cascade do |t|
     t.bigint "user_id"
-    t.string "status", default: "drafted", null: false
+    t.string "status", default: "DRAFTED", null: false
     t.string "name", null: false
     t.text "description"
     t.string "street"
@@ -236,9 +236,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_15_192708) do
     t.string "press_outlet"
     t.boolean "can_use_first_name", default: false
     t.boolean "can_share_crafter_details", default: false
-    t.string "has_materials"
     t.text "material_brand"
     t.string "inbound_email_address"
+    t.string "has_materials"
     t.string "needs_attention"
     t.index ["group_manager_id"], name: "index_projects_on_group_manager_id"
     t.index ["inbound_email_address"], name: "index_projects_on_inbound_email_address", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_18_183845) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_22_115749) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -193,7 +193,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_18_183845) do
 
   create_table "projects", force: :cascade do |t|
     t.bigint "user_id"
-    t.string "status", default: "DRAFTED", null: false
+    t.string "status", default: "PROPOSED", null: false
     t.string "name", null: false
     t.text "description"
     t.string "street"

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -194,18 +194,18 @@ module Manage
 
     test "search by status" do
       result = create_search_project
-      result.update!(status: "proposed")
+      result.update!(status: "PROPOSED")
 
-      assert_search_results([result], status: "proposed")
-      assert_search_no_results(status: "drafted")
+      assert_search_results([result], status: "PROPOSED")
+      assert_search_no_results(status: "DRAFTED")
     end
 
     test "search without status ignores status=test" do
       result = create_search_project
-      result.update!(status: "test")
+      result.update!(status: "TEST")
 
       assert_search_no_results({})
-      assert_search_results([result], status: "test")
+      assert_search_results([result], status: "TEST")
     end
 
     test "search by assigned" do

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -41,7 +41,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("DRAFTED"), not null
+#  status                    :string           default("PROPOSED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -41,7 +41,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("drafted"), not null
+#  status                    :string           default("DRAFTED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean
@@ -71,7 +71,7 @@ one:
   user_id: 5
   name: Project Title One
   description: Project desc one.
-  status: proposed
+  status: PROPOSED
   phone_number: 1234567890
   craft_type: knitting
   has_pattern: true
@@ -91,7 +91,7 @@ two:
   user_id: 2
   name: Project Title Two
   description: Project desc two.
-  status: ready to match
+  status: "READY TO MATCH: NEW"
   phone_number: 1234567890
   craft_type: knitting
   inbound_email_address: Project-t4Tzy9NI@localhost

--- a/test/jobs/send_check_ins_job_test.rb
+++ b/test/jobs/send_check_ins_job_test.rb
@@ -4,6 +4,10 @@ require "test_helper"
 
 class SendCheckInsJobTest < ActiveJob::TestCase
 
+  def setup
+    Project.find(1).update_column("status", "IN PROCESS: UNDERWAY")
+  end
+
   test "logs output" do
     SendCheckInsJob.perform_now
     assert_match "#<SendCheckInsJob:0x0", JobLog.last.output

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -61,7 +61,7 @@ class AssignmentTest < ActiveSupport::TestCase
   end
 
   test "allows known status" do
-    Assignment::STATUS.each do |status|
+    Assignment::STATUSES.values.each do |status|
       @assignment.status = status
 
       assert_predicate @assignment, :valid?, "Status #{status} should be valid"

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -69,6 +69,7 @@ class AssignmentTest < ActiveSupport::TestCase
   end
 
   test "needs_check_in does not include assignments with recent check-ins" do
+    Project.find(1).update_column("status", "IN PROCESS: UNDERWAY")
     assignment = Assignment.needs_check_in.first
     assert_equal 1, Assignment.needs_check_in.count
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -115,14 +115,14 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not_predicate(@project, :valid?, "Short phone number should not be allowed")
   end
 
-  test "status defaults to proposed if the project IS NOT missing information" do
+  test "status defaults to PROPOSED if the project IS NOT missing information" do
     @project.status = nil
     @project.save!
 
     assert_equal("PROPOSED", @project.reload.status)
   end
 
-  test "status defaults to drafted if the project IS missing information" do
+  test "status defaults to PROPOSED if the project IS missing information" do
     @project.has_pattern = nil
     @project.status = nil
     @project.save!

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -43,7 +43,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("drafted"), not null
+#  status                    :string           default("DRAFTED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean
@@ -119,7 +119,7 @@ class ProjectTest < ActiveSupport::TestCase
     @project.status = nil
     @project.save!
 
-    assert_equal("proposed", @project.reload.status)
+    assert_equal("PROPOSED", @project.reload.status)
   end
 
   test "status defaults to drafted if the project IS missing information" do
@@ -127,7 +127,7 @@ class ProjectTest < ActiveSupport::TestCase
     @project.status = nil
     @project.save!
 
-    assert_equal("drafted", @project.reload.status)
+    assert_equal("DRAFTED", @project.reload.status)
   end
 
   test "invalid status rejected" do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -43,7 +43,7 @@
 #  ready_status              :string
 #  recipient_name            :string
 #  state                     :string
-#  status                    :string           default("DRAFTED"), not null
+#  status                    :string           default("PROPOSED"), not null
 #  street                    :string
 #  street_2                  :string
 #  terms_of_use              :boolean
@@ -127,7 +127,7 @@ class ProjectTest < ActiveSupport::TestCase
     @project.status = nil
     @project.save!
 
-    assert_equal("DRAFTED", @project.reload.status)
+    assert_equal("PROPOSED", @project.reload.status)
   end
 
   test "invalid status rejected" do


### PR DESCRIPTION
We had three status columns on Project:  `status`, `ready_status`, and `in_process_status`, with the latter two being substatuses.  It complicated the UI and managers weren't consistent about using substatuses.  So, this PR flattens the status list (packs any necessary substatuses into the string), simplifies the UI, and migrates old values into new ones through `rake backfill:convert_project_status`.  It also updates `Assignment.needs_check_in` to consider project status in addition to Assignment status.  This is the new list

```
  STATUSES = [
    "PROPOSED",
    "WAITING PROJECT CONFIRMATION",
    "READY TO MATCH: NEW",
    "READY TO MATCH: ADDITIONAL ATTEMPT",
    "READY TO MATCH: NEEDS SECOND SKILL",
    "READY TO MATCH: REMATCH REQUESTED",
    "FINISHER INVITED",
    "ACCEPTED WAITING TERMS",
    "INTRODUCED",
    "IN PROCESS: CONNECTED",
    "IN PROCESS: WAITING HANDOFF",
    "IN PROCESS: UNDERWAY",
    "IN PROCESS: PO UNRESPONSIVE",
    "FINISHED NOT RETURNED",
    "DONE",
    "ON HOLD",
    "WILL NOT DO",
    "TEST"
  ].freeze
```

Project show header allows direct update of status
<img width="936" alt="image" src="https://github.com/user-attachments/assets/09e448c1-11b8-4d9e-a5cf-9e319004af40" />

Edit view has flat select
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/55b133df-efbe-4b83-a524-05367b814448" />

Project search respects flat list w/ counts
<img width="705" alt="image" src="https://github.com/user-attachments/assets/444e9b03-d471-4531-b0ae-de04ae29d7a0" />
