### PR TITLE
Make clipboard copy untility more robust

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -239,6 +239,7 @@ h1.project-name
     background: $yellow-100
     padding: 0.5rem
     border-radius: 0.5rem
+    user-select: none
 
 // pagination
 .pagination a, .pagination span, .pagination em

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,12 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 const CopyDelayMs = 800
+const CopySupportedClass = "copy-supported"
 const CopyClass = "copied"
 
 export default class extends Controller {
   connect() {
     if ("clipboard" in navigator) {
-      this.element.classList.add("copy-supported")
+      this.element.classList.add(CopySupportedClass)
       this.element.setAttribute("aria-label", "Copy to clipboard")
       this.element.addEventListener("click", this.copy.bind(this))
     }
@@ -15,6 +16,11 @@ export default class extends Controller {
   copy(event) {
     let textForCopy = this.element.textContent
     event.preventDefault()
+
+    if (! this.element.classList.contains(CopySupportedClass)) {
+      // Clipboard API not supported or returning errors. Do nothing.
+      return
+    }
 
     if (this.element.classList.contains(CopyClass)) {
       // Copy already in progress. Don't copy "Copied!" on double click.
@@ -26,6 +32,7 @@ export default class extends Controller {
         this.showCopyFeedback(textForCopy)
       },
       (err) => {
+        this.element.classList.remove(CopySupportedClass)
         console.error("Could not copy text: ", err)
       }
     )

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 const CopyDelayMs = 1000
+const CopyClass = "copied"
 
 export default class extends Controller {
   connect() {
@@ -14,12 +15,18 @@ export default class extends Controller {
   copy(event) {
     let textForCopy = this.element.textContent
     event.preventDefault()
+
+    if (this.element.classList.contains(CopyClass)) {
+      // Copy already in progress. Don't copy "Copied!" on double click.
+      return
+    }
+
     navigator.clipboard.writeText(textForCopy)
-    this.element.classList.add("copied")
+    this.element.classList.add(CopyClass)
     this.element.textContent = "Copied!"
 
     setTimeout(() => {
-      this.element.classList.remove("copied")
+      this.element.classList.remove(CopyClass)
       this.element.textContent
        = textForCopy
     }, CopyDelayMs)

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const CopyDelayMs = 1000
+const CopyDelayMs = 800
 const CopyClass = "copied"
 
 export default class extends Controller {
@@ -21,7 +21,17 @@ export default class extends Controller {
       return
     }
 
-    navigator.clipboard.writeText(textForCopy)
+    navigator.clipboard.writeText(textForCopy).then(
+      () => {
+        this.showCopyFeedback(textForCopy)
+      },
+      (err) => {
+        console.error("Could not copy text: ", err)
+      }
+    )
+  }
+
+  showCopyFeedback(textForCopy) {
     this.element.classList.add(CopyClass)
     this.element.textContent = "Copied!"
 


### PR DESCRIPTION
There were some reports in Slack of the copy to clipboard utility not working correctly. I could not reproduce them but in at least one case someone mentioned refreshing solved it. I did a few different things to make it more robust:

1. Use the Promise returned by `navigator.clipboard.writeText` to catch errors. In this case copy is disabled so the user can select the text the old fashioned way.
2. Do not copy-on-click when showing the copy confirmation. That way a double-click does not copy the text "Coped!"
3. Cleanup some duplicated strings