### PR TITLE
Make the "SAVED" label on Turbo updates simpler

### DIFF
--- a/app/assets/stylesheets/animations.sass
+++ b/app/assets/stylesheets/animations.sass
@@ -1,0 +1,6 @@
+
+@keyframes fade-out
+  0%
+    opacity: 1
+  100%
+    opacity: 0

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -4,12 +4,7 @@
 @import "@fortawesome/fontawesome-free/scss/solid"
 @import "@fortawesome/fontawesome-free/scss/brands"
 @import "./actiontext.css"
-
-@keyframes fade-out
-  0%
-    opacity: 1
-  100%
-    opacity: 0
+@import "./animations"
 
 // Finishers
 

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -5,6 +5,12 @@
 @import "@fortawesome/fontawesome-free/scss/brands"
 @import "./actiontext.css"
 
+@keyframes fade-out
+  0%
+    opacity: 1
+  100%
+    opacity: 0
+
 // Finishers
 
 .unavailable
@@ -98,14 +104,10 @@ h1.assigned
   font-size: 0.8rem
   padding: 0.25rem
 
-  .visible
-    visibility: visible
+  &.visible
     opacity: 1
     transition: opacity 2s linear
-  .hidden
-    visibility: hidden
-    opacity: 0
-    transition: visibility 0s 2s, opacity 2s linear
+    animation: fade-out 300ms linear 1s forwards
 
 // Breadcrumbs
 

--- a/app/views/manage/_update_label.html.haml
+++ b/app/views/manage/_update_label.html.haml
@@ -1,0 +1,4 @@
+- if did_save
+  %span.update-flash.visible SAVED
+- else
+  %span.update-flash.opacity-0 SAVED

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -29,13 +29,3 @@
         %span.update-flash.visible SAVED
       - else
         %span.update-flash.opacity-0 SAVED
-
-
-:javascript
-  setTimeout(() => {
-    let visibleFlashSelector = document.querySelector('.update-flash.visible');
-    if (visibleFlashSelector) {
-      visibleFlashSelector.classList.remove('visible')
-      visibleFlashSelector.classList.add('opacity-0')
-    }
-  }, 1000)

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -25,7 +25,4 @@
           = (assignment.status || 'Unknown').titleize
       - else
         = form.select :status,  [['Unknown', nil]] + Assignment::STATUSES.values.map{|s| [s.titleize, s] }, {}, { class: 'd-inline form-select form-select-sm w-auto', autocomplete: 'off', onchange: 'this.form.requestSubmit()' }
-      - if assignment.saved_change_to_status?
-        %span.update-flash.visible SAVED
-      - else
-        %span.update-flash.opacity-0 SAVED
+      = render partial: 'manage/update_label', locals: { did_save: assignment.saved_change_to_status? }

--- a/app/views/manage/projects/_needs_attention_form.html.haml
+++ b/app/views/manage/projects/_needs_attention_form.html.haml
@@ -4,8 +4,5 @@
     { include_blank: false },
     { id: "needs-attention-select", class: "form-select", autocomplete: 'off',
       onchange: 'this.form.requestSubmit()' }
-  - if project.saved_change_to_needs_attention?
-    %span.update-flash.visible SAVED
-  - else
-    %span.update-flash.opacity-0 SAVED
+  = render partial: 'manage/update_label', locals: { did_save: project.saved_change_to_needs_attention? }
   .pb-1 &nbsp;

--- a/app/views/manage/projects/_needs_attention_form.html.haml
+++ b/app/views/manage/projects/_needs_attention_form.html.haml
@@ -9,12 +9,3 @@
   - else
     %span.update-flash.opacity-0 SAVED
   .pb-1 &nbsp;
-
-:javascript
-  setTimeout(() => {
-    let visibleFlashSelector = document.querySelector('.update-flash.visible');
-    if (visibleFlashSelector) {
-      visibleFlashSelector.classList.remove('visible')
-      visibleFlashSelector.classList.add('opacity-0')
-    }
-  }, 1000)

--- a/app/views/manage/projects/_project_status_form.html.haml
+++ b/app/views/manage/projects/_project_status_form.html.haml
@@ -4,7 +4,4 @@
     { include_blank: false },
     { id: "project-status-select", class: "form-select", autocomplete: 'off',
       onchange: 'this.form.requestSubmit()' }
-  - if project.saved_change_to_status?
-    %span.update-flash.visible SAVED
-  - else
-    %span.update-flash.opacity-0 SAVED
+  = render partial: 'manage/update_label', locals: { did_save: project.saved_change_to_status? }

--- a/app/views/manage/projects/_project_status_form.html.haml
+++ b/app/views/manage/projects/_project_status_form.html.haml
@@ -8,12 +8,3 @@
     %span.update-flash.visible SAVED
   - else
     %span.update-flash.opacity-0 SAVED
-
-:javascript
-  setTimeout(() => {
-    let visibleFlashSelector = document.querySelector('.update-flash.visible');
-    if (visibleFlashSelector) {
-      visibleFlashSelector.classList.remove('visible')
-      visibleFlashSelector.classList.add('opacity-0')
-    }
-  }, 1000)


### PR DESCRIPTION
As a follow up to some discussion on #353 I looked at making the temporary "SAVED" label component more reusable. I was going to following something like #302 but when I thought it through it turned out Stimulus was overkill. I was able to simplify this to not use Javascript at all. This now uses a CSS animation and delay so any properly formed markup Just Works™. Since the markup needs are a little specific I moved that into a partial as well to make it easy to use.