### PR TITLE
HOTFIXES post 2025-04-24 release

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -126,6 +126,8 @@ class Message < ApplicationRecord
     return unless assignment
 
     return unless assignment.project.status.match(/^in process/i)
-    assignment.update_attribute(:last_contacted_at, Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+
+    # HACK Temporarily disable update.  Need to make the logic smarter
+    # assignment.update_attribute(:last_contacted_at, Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
   end
 end

--- a/app/views/projects/_crafter_form_fields.html.haml
+++ b/app/views/projects/_crafter_form_fields.html.haml
@@ -14,7 +14,7 @@
   .col-md-4
     = form.file_field :append_crafter_images, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp", :multiple => true
     - form.object.crafter_images.each do |image|
-      - if image.variable?
+      - if image.id.present? # Rails bug https://github.com/rails/rails/issues/50234
         = image_tag image.representation( resize_to_limit: [100, 100])
     .form-info Please upload photos of the crafter, if you have them.
 .row.mb-4

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -56,6 +56,22 @@ class ProjectsControllerTest < ActionController::TestCase
     assert_redirected_to project_path(new_project)
   end
 
+  test "should fail to create on invalid phone with image" do
+    sign_in @project.user
+    post :create, params: {
+      project: {
+        name: "New Project",
+        phone_number: "123", # too short
+        description: "Description here",
+        craft_type: "Knitting",
+        append_project_images: [fixture_file_upload("test.jpg")],
+        append_crafter_images: [fixture_file_upload("test.jpg")]
+      }
+    }
+
+    assert_response :success
+  end
+
   test "should update project" do
     sign_in @project.user
     patch :update, params: {

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -59,7 +59,7 @@ class MessageTest < ActiveSupport::TestCase
 
   test "Updates assignment last_contacted_at for Project" do
     project = Project.first
-    project.status = "in process"
+    project.status = "IN PROCESS: UNDERWAY"
     assignment = project.active_assignment
     assignment.update_attribute("last_contacted_at", nil) # set up fixture
 
@@ -71,7 +71,9 @@ class MessageTest < ActiveSupport::TestCase
     m.content = "Primo content"
     m.save!
 
-    assert_not_nil(assignment.reload.last_contacted_at)
+    # HACK Temporarily disabled updating
+    #
+    assert_nil(assignment.reload.last_contacted_at)
   end
 
   test "does not update last_contacted_at unless active assignment and project in process" do


### PR DESCRIPTION
- Temporarily disable auto-update of assignments.last_contacted_at triggered by inbound emails
- Fix crafter image template errors on validation failure