### PR TITLE
Fix copy/paste bug and browser console warning

### DIFF
--- a/app/views/manage/projects/_project_row.html.haml
+++ b/app/views/manage/projects/_project_row.html.haml
@@ -4,11 +4,11 @@
   %td.text-nowrap
     - if last_contact = project.assignments.where(finisher: project.active_finisher).maximum('last_contacted_at')
       = time_tag(last_contact, "#{time_ago_in_words(last_contact)} ago", title: last_contact)
-  %td.text-nowrap= link_to project.user.email, [:admin, project.user], 'data-controller' => 'clipboard'
+  %td.text-nowrap= link_to project.user.email, [:admin, project.user], data: { controller: 'clipboard', turbo: false }
   %td.text-nowrap
     - if project.active_finisher.present? && assignment = project.assignments.where(finisher: project.active_finisher).first
-      = link_to project.active_finisher&.user&.email, [:manage, project.active_finisher], 'data-controller' => 'clipboard'
+      = link_to project.active_finisher&.user&.email, [:manage, project.active_finisher], data: { controller: 'clipboard', turbo: false }
       %span.ms-1.badge.rounded-pill.text-bg-primary= assignment.status
     - elsif project.finisher.present? && assignment = project.assignments.where(finisher: project.finisher).first
-      = link_to project.finisher&.user&.email, [:manage, project.finisher], 'data-controller' => 'clipboard'
+      = link_to project.finisher&.user&.email, [:manage, project.finisher], data: { controller: 'clipboard', turbo: false }
       %span.badge.rounded-pill.text-bg-secondary= assignment.status

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -45,7 +45,11 @@
   };
 
   var setupSortHeaders = () => {
-    const currentSort = document.getElementById('sort').value
+    const sortElement = document.getElementById('sort')
+    if (! sortElement) {
+      return
+    }
+    const currentSort = sortElement.value
     const sortableHeaders = document.getElementsByClassName('sortable')
 
     for (var i=0; i < sortableHeaders.length; i++) {


### PR DESCRIPTION
While testing the new links+copy added in #365 on staging I ran into an error. If the link was followed, and then the back button used, a browser console warning was thrown and both column sort and copy stopped working. The root cause is something with how Turbolinks is reloading pages. Since the speed of these requests is fast I disabled the Turbo loading in this case so it works correctly while I research other solutions.