### PR TITLE
Expose confirmed/unconfirmed email addresses

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -19,6 +19,11 @@
   border-top-left-radius: 5px
   border-top-right-radius: 5px
 
+.email-not-confirmed
+  color: #aaa
+  font-size: 0.75em
+  font-style: italic
+
 h1.assigned
   color: red
 

--- a/app/controllers/manage/finishers_controller.rb
+++ b/app/controllers/manage/finishers_controller.rb
@@ -118,6 +118,7 @@ module Manage
                                        :phone_number,
                                        :approved,
                                        :unavailable,
+                                       :confirm_email,
                                        :joined_on,
                                        :chosen_name,
                                        :dominant_hand,

--- a/app/controllers/manage/reports_controller.rb
+++ b/app/controllers/manage/reports_controller.rb
@@ -1,5 +1,7 @@
 class Manage::ReportsController < Manage::ManageController
+
   # Add route for each report and link on dashboard
+  # @results is a 2-D array [[col1, col2, col3], [col1, col2, col3],...]
 
   def heard_about_us
     @description = 'Counts of user records by heard_about_us value'

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,13 +22,19 @@ module Users
         end
       end
 
-      # If the action needs to do anything before redirect
+      # Pass a block if the action needs to do anything before redirect
       #
       def attempt_locate(&block)
         message = GlobalID::Locator.locate_signed(params[:sgid])
         if message.present? && message.user.is_a?(User)
           message.increment!(:click_count)
+
           sign_in(message.user)
+
+          # If they follow any magic link, confirm the email
+          #
+          message.user.update_attribute(:confirmed_at, Time.zone.now) \
+            unless message.user.confirmed?
 
           yield if block_given?
 

--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -183,6 +183,10 @@ class Finisher < ApplicationRecord
     finished_projects.attach(attachables)
   end
 
+  def confirm_email=(value)
+    user.update_attribute(:confirmed_at, Time.zone.now) if value == "1"
+  end
+
   def send_welcome_message
     FinisherMailer.with(resource: self).welcome.deliver_now
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,6 @@
 #
 class User < ApplicationRecord
   ROLES = %w[user manager admin].freeze
-  MAGIC_LINK_DEFAULT_DURATION = 48.hours
 
   include LooseEndsSearchable
 

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -45,4 +45,4 @@
     .col
       %hr
       %h3 Reports
-      = link_to 'Heard About Us', 'reports/heard_about_us'
+      .pt-0= link_to 'Heard About Us', 'reports/heard_about_us'

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -39,3 +39,5 @@
 
   .card-footer
     #{finisher.city}, #{finisher.state}
+    - unless finisher.user.confirmed?
+      .email-not-confirmed Email Not Confirmed

--- a/app/views/manage/finishers/_finisher_row.html.haml
+++ b/app/views/manage/finishers/_finisher_row.html.haml
@@ -1,7 +1,13 @@
 %tr
   %td
     = link_to finisher.name, [:manage, finisher]
-  %td= finisher.user.email
+  %td
+    = finisher.user.email
+  %td
+    - if finisher.user.confirmed?
+      %span.badge.bg-primary CONFIRMED
+    - else
+      %span.badge.bg-secondary UNCONFIRMED
   %td= finisher.full_address
   - if @project
     %td= link_to 'Assign', [:new, :manage, @project, :assignment, { finisher_id: finisher.id }]

--- a/app/views/manage/finishers/_form.html.haml
+++ b/app/views/manage/finishers/_form.html.haml
@@ -23,6 +23,11 @@
     = form.label :joined_on, class: 'col-2 col-form-label'
     .col-4
       = form.date_field :joined_on, class: 'form-control'
+    - unless @finisher.user.confirmed?
+      .col-lg-3
+        = form.label :confirm_email do
+          = form.check_box :confirm_email
+          Confirm email address
   .row.mb-2
     = form.label :phone_number, class: 'col-2 col-form-label'
     .col-4

--- a/app/views/manage/finishers/map.html.haml
+++ b/app/views/manage/finishers/map.html.haml
@@ -30,6 +30,7 @@
       %tr
         %th Name
         %th Email
+        %th Email Status
         %th Address
         - if @project
           %th Assign
@@ -69,8 +70,8 @@
       new google.maps.Marker({ position: { lat: #{@center[0]}, lng: #{@center[1]} }, zIndex: 9999, icon: projectIcon, label: projectLabel, map, optimized: false });
 
       const finishers = [
-        #{ 
-          @finishers.map do |f| 
+        #{
+          @finishers.map do |f|
             "{ position: { lat: #{f.latitude}, lng: #{f.longitude} }, title: '#{escape_javascript(f.name)}', skills: '#{f.rated_skills_string}', has_volunteer_time_off: #{f.has_volunteer_time_off.to_json}, url: '#{url_for([:card, :manage, @project, f])}', zIndex: #{@skill_id ? f.assessments.find_by(skill_id: @skill_id).rating : 0} }"
           end.join(',')
         }
@@ -98,8 +99,6 @@
           scale: 2,
           labelOrigin: labelOriginFilled
         }
-        
-        
 
         const label = {
           text: labelText,

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -32,6 +32,8 @@
     .page-section.mb-2
       %b Email:
       %span{ data: { controller: 'clipboard' } }= @finisher.user.email
+      - unless @finisher.user.confirmed?
+        .email-not-confirmed Email Not Confirmed
     .page-section.mb-2
       %b Phone Number:
       = @finisher.phone_number

--- a/app/views/messages/_index.html.haml
+++ b/app/views/messages/_index.html.haml
@@ -13,14 +13,14 @@
     %table
       %thead
         %tr
-          %th Sent
+          %th Date
           %th From
           %th Subject
           %th.text-center Attachments
           %th.text-end Size
           %th &nbsp;
       %tbody
-        - resource.messages.each do |message|
+        - resource.messages.order(created_at: :desc).each do |message|
           - next unless message.valid_headers?
           %tr
             %td= DateTime.parse(message.email_headers["date"]).to_formatted_s(:compact)

--- a/test/controllers/manage/finishers_controller_test.rb
+++ b/test/controllers/manage/finishers_controller_test.rb
@@ -147,5 +147,27 @@ module Manage
 
       assert(finisher.has_volunteer_time_off)
     end
+
+    test "can update user.confirmed_at" do
+      sign_in @user
+
+      finisher = finishers(:crocheter)
+      params = {
+        id: finisher.id,
+        finisher: finisher.attributes.merge(
+          "street" => "123 Main St",
+          "city" => "Anytown",
+          "state" => "WA",
+          "postal_code" => "12345",
+          "country" => "US",
+          "confirm_email" => "1"
+        )
+      }
+      patch :update, params: params
+
+      finisher.reload
+
+      assert(finisher.user.confirmed?)
+    end
   end
 end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -19,9 +19,12 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'good magic link does the necessary' do
     travel_to @message.expires_at - 1.day
+
+    refute_predicate @message.user, :confirmed?
     get "/magic_link", params: { sgid: @message.sgid }
     assert_redirected_to @message.redirect_to
     assert_equal 1, @message.reload.click_count
+    assert_predicate @message.user, :confirmed?
   end
 
   test 'fake SGID throws 404' do


### PR DESCRIPTION
We started using Devise `:confirmable` in March, so there are 30k Finisher accounts with unconfirmed emails.  Having an unconfirmed email address doesn't prevent anything from happening, but does result in some number of Finishers being marked "Unavailable".  Before making major changes to sign-up-related emails, we should redesign the Finisher onboarding experience.

So, all this PR does is show email confirmation status in various Finisher views.  It also add's a checkbox on manage/finisher/edit to force-confirm an email address.  It also confirms an unconfirmed email anytime a user follows a magic link.  There are also two minor unrelated commits (sort messages desc and remove deprecated constant).