### PR TITLE
Expose confirmed/unconfirmed email addresses (#373)

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -19,6 +19,11 @@
   border-top-left-radius: 5px
   border-top-right-radius: 5px
 
+.email-not-confirmed
+  color: #aaa
+  font-size: 0.75em
+  font-style: italic
+
 h1.assigned
   color: red
 

--- a/app/controllers/manage/finishers_controller.rb
+++ b/app/controllers/manage/finishers_controller.rb
@@ -118,6 +118,7 @@ module Manage
                                        :phone_number,
                                        :approved,
                                        :unavailable,
+                                       :confirm_email,
                                        :joined_on,
                                        :chosen_name,
                                        :dominant_hand,

--- a/app/controllers/manage/reports_controller.rb
+++ b/app/controllers/manage/reports_controller.rb
@@ -1,5 +1,7 @@
 class Manage::ReportsController < Manage::ManageController
+
   # Add route for each report and link on dashboard
+  # @results is a 2-D array [[col1, col2, col3], [col1, col2, col3],...]
 
   def heard_about_us
     @description = 'Counts of user records by heard_about_us value'

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,13 +22,19 @@ module Users
         end
       end
 
-      # If the action needs to do anything before redirect
+      # Pass a block if the action needs to do anything before redirect
       #
       def attempt_locate(&block)
         message = GlobalID::Locator.locate_signed(params[:sgid])
         if message.present? && message.user.is_a?(User)
           message.increment!(:click_count)
+
           sign_in(message.user)
+
+          # If they follow any magic link, confirm the email
+          #
+          message.user.update_attribute(:confirmed_at, Time.zone.now) \
+            unless message.user.confirmed?
 
           yield if block_given?
 

--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -183,6 +183,10 @@ class Finisher < ApplicationRecord
     finished_projects.attach(attachables)
   end
 
+  def confirm_email=(value)
+    user.update_attribute(:confirmed_at, Time.zone.now) if value == "1"
+  end
+
   def send_welcome_message
     FinisherMailer.with(resource: self).welcome.deliver_now
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,6 @@
 #
 class User < ApplicationRecord
   ROLES = %w[user manager admin].freeze
-  MAGIC_LINK_DEFAULT_DURATION = 48.hours
 
   include LooseEndsSearchable
 

--- a/app/views/manage/dashboards/show.html.haml
+++ b/app/views/manage/dashboards/show.html.haml
@@ -45,4 +45,4 @@
     .col
       %hr
       %h3 Reports
-      = link_to 'Heard About Us', 'reports/heard_about_us'
+      .pt-0= link_to 'Heard About Us', 'reports/heard_about_us'

--- a/app/views/manage/finishers/_finisher_card.html.haml
+++ b/app/views/manage/finishers/_finisher_card.html.haml
@@ -39,3 +39,5 @@
 
   .card-footer
     #{finisher.city}, #{finisher.state}
+    - unless finisher.user.confirmed?
+      .email-not-confirmed Email Not Confirmed

--- a/app/views/manage/finishers/_finisher_row.html.haml
+++ b/app/views/manage/finishers/_finisher_row.html.haml
@@ -1,7 +1,13 @@
 %tr
   %td
     = link_to finisher.name, [:manage, finisher]
-  %td= finisher.user.email
+  %td
+    = finisher.user.email
+  %td
+    - if finisher.user.confirmed?
+      %span.badge.bg-primary CONFIRMED
+    - else
+      %span.badge.bg-secondary UNCONFIRMED
   %td= finisher.full_address
   - if @project
     %td= link_to 'Assign', [:new, :manage, @project, :assignment, { finisher_id: finisher.id }]

--- a/app/views/manage/finishers/_form.html.haml
+++ b/app/views/manage/finishers/_form.html.haml
@@ -23,6 +23,11 @@
     = form.label :joined_on, class: 'col-2 col-form-label'
     .col-4
       = form.date_field :joined_on, class: 'form-control'
+    - unless @finisher.user.confirmed?
+      .col-lg-3
+        = form.label :confirm_email do
+          = form.check_box :confirm_email
+          Confirm email address
   .row.mb-2
     = form.label :phone_number, class: 'col-2 col-form-label'
     .col-4

--- a/app/views/manage/finishers/map.html.haml
+++ b/app/views/manage/finishers/map.html.haml
@@ -30,6 +30,7 @@
       %tr
         %th Name
         %th Email
+        %th Email Status
         %th Address
         - if @project
           %th Assign
@@ -69,8 +70,8 @@
       new google.maps.Marker({ position: { lat: #{@center[0]}, lng: #{@center[1]} }, zIndex: 9999, icon: projectIcon, label: projectLabel, map, optimized: false });
 
       const finishers = [
-        #{ 
-          @finishers.map do |f| 
+        #{
+          @finishers.map do |f|
             "{ position: { lat: #{f.latitude}, lng: #{f.longitude} }, title: '#{escape_javascript(f.name)}', skills: '#{f.rated_skills_string}', has_volunteer_time_off: #{f.has_volunteer_time_off.to_json}, url: '#{url_for([:card, :manage, @project, f])}', zIndex: #{@skill_id ? f.assessments.find_by(skill_id: @skill_id).rating : 0} }"
           end.join(',')
         }
@@ -98,8 +99,6 @@
           scale: 2,
           labelOrigin: labelOriginFilled
         }
-        
-        
 
         const label = {
           text: labelText,

--- a/app/views/manage/finishers/show.html.haml
+++ b/app/views/manage/finishers/show.html.haml
@@ -32,6 +32,8 @@
     .page-section.mb-2
       %b Email:
       %span{ data: { controller: 'clipboard' } }= @finisher.user.email
+      - unless @finisher.user.confirmed?
+        .email-not-confirmed Email Not Confirmed
     .page-section.mb-2
       %b Phone Number:
       = @finisher.phone_number

--- a/app/views/manage/job_logs/_compact.html.haml
+++ b/app/views/manage/job_logs/_compact.html.haml
@@ -6,5 +6,5 @@
   %tbody
     - job_logs.each do |log|
       %tr( onclick="document.location = '#{manage_job_log_path(log)}';" )
-        %td= log.created_at.to_formatted_s(:human)
+        %td= log.created_at.in_time_zone(Time.zone).to_formatted_s(:compact)
         %td= truncate(log.output, length: 100)

--- a/app/views/manage/notes/_compact.html.haml
+++ b/app/views/manage/notes/_compact.html.haml
@@ -10,7 +10,7 @@
   %tbody
     - notes.each do |n|
       %tr
-        %td= n.created_at.to_formatted_s(:human)
+        %td= n.created_at.in_time_zone(Time.zone).to_formatted_s(:compact)
         %td= link_to n.notable.name, manage_project_path(n.notable.project)
         %td= n.notable.finisher.name
         %td= n.notable.project.manager&.name

--- a/app/views/messages/_compact.html.haml
+++ b/app/views/messages/_compact.html.haml
@@ -13,7 +13,7 @@
     - messages.each do |m|
       - next unless m.valid_headers?
       %tr
-        %td= DateTime.parse(m.email_headers["date"]).to_formatted_s(:compact)
+        %td= DateTime.parse(m.email_headers["date"]).in_time_zone(Time.zone).to_formatted_s(:compact)
         %td #{ format == 'inbound' ? m.email_headers["from"]&.join(", ") : m.email_headers["to"]&.join(", ") }
         %td
           %a(href="#{m.path_to_messageable}") #{m.description}

--- a/app/views/messages/_index.html.haml
+++ b/app/views/messages/_index.html.haml
@@ -13,17 +13,17 @@
     %table
       %thead
         %tr
-          %th Sent
+          %th Date
           %th From
           %th Subject
           %th.text-center Attachments
           %th.text-end Size
           %th &nbsp;
       %tbody
-        - resource.messages.each do |message|
+        - resource.messages.order(created_at: :desc).each do |message|
           - next unless message.valid_headers?
           %tr
-            %td= DateTime.parse(message.email_headers["date"]).to_formatted_s(:compact)
+            %td= DateTime.parse(message.email_headers["date"]).in_time_zone(Time.zone).to_formatted_s(:compact)
             %td= message.email_headers["from"]&.join(", ")
             %td= link_to message.email_headers["subject"], message
             %td.text-center= message.email_headers["attachments"] > 0 ? fa_icon("paperclip") : ""

--- a/app/views/messages/show.html.haml
+++ b/app/views/messages/show.html.haml
@@ -18,34 +18,22 @@
             %td Subject
             %td= @message.email.subject
 
-
   - if @message.email.html_part.present?
     .row
       .col
-        %p.pt-3.fw-bold HTML Part
         %p.pt-0= @message.email.html_part.decoded.html_safe
-        %hr
+
+  - if @message.email.text_part.present? && !@message.email.html_part.present?
+    .row
+      .col
+        %p.pt-0
+          %pre= @message.email.text_part.decoded
 
   .row
     - @message.email.attachments.each do |attachment|
       .col-4
         %img.img-fluid(src="data:#{attachment.content_type};base64,#{Base64.encode64(attachment.body.decoded).html_safe}")
         %figcaption.figure-caption= attachment.content_type
-
-  - if @message.email.text_part.present?
-    .row
-      .col
-        %p.pt-3.fw-bold Text Part
-        %p.pt-0
-          %pre= @message.email.text_part.decoded
-
-        %hr
-
-  %hr
-  .row
-    .col
-      %p.pt-3.fw-bold Raw Source
-      %pre= @message.email.raw_source
 
 - else
   .pt-0.fst-italic [no content]

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -50,8 +50,8 @@
 #  t.strftime("Printed on %m/%d/%Y")   #=> "Printed on 04/09/2003"
 #  t.strftime("at %I:%M%p")            #=> "at 08:56AM"
 
-# Custom
+# Custom formats
 
 Time::DATE_FORMATS[:month_and_year] = "%B %Y" # January 2025
 Time::DATE_FORMATS[:human] = "%a %b %d, %Y %I:%M%p %Z" # Thu Apr 03, 2025 02:08AM UTC
-Time::DATE_FORMATS[:compact] = "%m/%e/%y %I:%M%p %Z" # 04/6/25 08:53AM -5:00
+Time::DATE_FORMATS[:compact] = "%m/%d/%y %I:%M%p %Z" # 04/6/25 08:53AM -5:00

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,10 +10,20 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# LEP account
+# Default S3 storage for each environment (development, staging, production)
+#
 aws_s3:
   service: S3
   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-2
   bucket: looseendsproject-<%= ENV['RAILS_ENV_DISPLAY'] %>
+
+# Production S3 bucket used by scripts that rely on CopyBlobJob
+#
+aws_s3_production:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: us-east-2
+  bucket: looseendsproject-production

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :dev do
+
+  ### Dev convenience tools
+
+  # You gotta have the prod AWS creds in your .env
+  #
+  desc "Copy most recent Message email_source attachments to development or staging S3 bucket"
+  task fetch_email_source: [:environment] do |_t|
+    exit if ENV["RAILS_ENV_DISPLAY"] == "production" # DO NOT DO THIS IN PROD
+
+    LIMIT = 100
+
+    messages = Message.where(channel: "inbound").order(created_at: :desc).limit(LIMIT)
+    messages.each do |message|
+      CopyBlobJob.perform_now(message.email_source.blob, "aws_s3_production", "aws_s3")
+    end
+  end
+
+end

--- a/test/controllers/manage/finishers_controller_test.rb
+++ b/test/controllers/manage/finishers_controller_test.rb
@@ -147,5 +147,27 @@ module Manage
 
       assert(finisher.has_volunteer_time_off)
     end
+
+    test "can update user.confirmed_at" do
+      sign_in @user
+
+      finisher = finishers(:crocheter)
+      params = {
+        id: finisher.id,
+        finisher: finisher.attributes.merge(
+          "street" => "123 Main St",
+          "city" => "Anytown",
+          "state" => "WA",
+          "postal_code" => "12345",
+          "country" => "US",
+          "confirm_email" => "1"
+        )
+      }
+      patch :update, params: params
+
+      finisher.reload
+
+      assert(finisher.user.confirmed?)
+    end
   end
 end

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -19,9 +19,12 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'good magic link does the necessary' do
     travel_to @message.expires_at - 1.day
+
+    refute_predicate @message.user, :confirmed?
     get "/magic_link", params: { sgid: @message.sgid }
     assert_redirected_to @message.redirect_to
     assert_equal 1, @message.reload.click_count
+    assert_predicate @message.user, :confirmed?
   end
 
   test 'fake SGID throws 404' do


### PR DESCRIPTION
* Sort messages created_at desc on project/show

* Show email confirmation status, allow update on Finisher edit

* Confirm email on magic link click

* Remove deprecated constant

* Change :compact time format (%e?  what's the point if it inserts a space?)

* Rake task to copy email blobs for dev

* Clean up message/show for emails

* Standardize date display on dashboard