### PR TITLE
Escalate Project into "Needs Attention" after four check ins

### DIFF
--- a/app/jobs/send_check_ins_job.rb
+++ b/app/jobs/send_check_ins_job.rb
@@ -9,15 +9,31 @@ class SendCheckInsJob < ApplicationJob
     Assignment.needs_check_in.each do |assignment|
       ActiveRecord::Base.transaction do
 
-        FinisherMailer.with(resource: assignment,
-          expires_in: Assignment::CHECK_IN_INTERVAL).project_check_in.deliver_later
-        assignment.update_attribute("check_in_sent_at", Time.zone.now)
+        if assignment.missed_check_ins? # don't send another, but escalate
 
-        output += <<~LINE
-          #{assignment.finisher.user.email}\
-          \t\t\t#{assignment.finisher.user.name}\
-          \t\t\t#{assignment.project.name}
-        LINE
+          assignment.project.update_attribute(:needs_attention, "finisher_unresponsive")
+          assignment.update_attribute(:status, Assignment::STATUSES[:unresponsive])
+
+          output += <<~LINE
+            #{assignment.finisher.user.email}\
+            \t\t\t#{assignment.finisher.user.name}\
+            \t\t\t#{assignment.project.name}\
+            \t\t\tUNRESPONSIVE
+          LINE
+
+        else
+
+          FinisherMailer.with(resource: assignment,
+            expires_in: Assignment::CHECK_IN_INTERVAL).project_check_in.deliver_later
+          assignment.update_attribute("check_in_sent_at", Time.zone.now)
+
+          output += <<~LINE
+            #{assignment.finisher.user.email}\
+            \t\t\t#{assignment.finisher.user.name}\
+            \t\t\t#{assignment.project.name}
+          LINE
+
+        end
       end
     end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,8 +92,7 @@ class Project < ApplicationRecord
 
   BOOLEAN_ATTRIBUTES = %i[joann_helped urgent influencer group_project press privacy_needed].freeze
 
-  NEEDS_ATTENTION_REASONS = %w(negative_sentiment stalled_accepted
-    stalled_invited stalled_potential long_running)
+  NEEDS_ATTENTION_REASONS = %w(negative_sentiment finisher_unresponsive manager_hold)
 
   include LooseEndsSearchable
   include EmailAddressable

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -2,6 +2,3 @@ production:
   check_in_job:
     class: SendCheckInsJob
     schedule: every day at 12pm
-  # flag_stuck_projects:
-  #   class: FlagStuckProjectsJob
-  #   schedule: every Sunday at 8pm

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -119,7 +119,7 @@ module Manage
       @project = Project.first
       sign_in @user
 
-      patch "/manage/projects/#{@project.id}.turbo_stream", params: { project: { needs_attention: "stalled_accepted" } }
+      patch "/manage/projects/#{@project.id}.turbo_stream", params: { project: { needs_attention: "finisher_unresponsive" } }
       assert_match "<span class='update-flash visible'>SAVED</span>", response.body
     end
 

--- a/test/jobs/send_check_ins_job_test.rb
+++ b/test/jobs/send_check_ins_job_test.rb
@@ -39,4 +39,24 @@ class SendCheckInsJobTest < ActiveJob::TestCase
     assert_enqueued_jobs 1
     assert_not_equal time, Assignment.find(1).check_in_sent_at
   end
+
+  test "escalate unresponsive" do
+    @assignment = Assignment.find(1)
+    user = @assignment.finisher.user
+    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 8.weeks, user: user)
+    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 6.weeks, user: user)
+    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 4.weeks, user: user)
+    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 2.weeks, user: user)
+    @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
+    @assignment.update_attribute(:last_contacted_at,
+      Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_INTERVAL)
+
+    assert @assignment.missed_check_ins?
+
+    SendCheckInsJob.perform_now
+    assert_enqueued_jobs 0
+    assert_equal "finisher_unresponsive", @assignment.reload.project.needs_attention
+    assert_equal "unresponsive", @assignment.status
+    assert_match "UNRESPONSIVE", JobLog.last.output
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -81,7 +81,7 @@ class ProjectTest < ActiveSupport::TestCase
   end
 
   test "needing_attention scope" do
-    Project.first.update(needs_attention: "stalled_invited")
+    Project.first.update(needs_attention: "manager_hold")
     assert_equal 1, Project.needing_attention.count
 
     Project.first.update(needs_attention: "")
@@ -166,8 +166,8 @@ class ProjectTest < ActiveSupport::TestCase
 
   test "needs_attention_option returns proper struct" do
     assert_equal [["Negative Sentiment", "negative_sentiment"],
-      ["Stalled Accepted", "stalled_accepted"], ["Stalled Invited", "stalled_invited"],
-      ["Stalled Potential", "stalled_potential"], ["Long Running", "long_running"]],
+      ["Finisher Unresponsive", "finisher_unresponsive"],
+      ["Manager Hold", "manager_hold"]],
       Project.needs_attention_options
   end
 


### PR DESCRIPTION
For Assignments in "Accepted" status with Projects in "IN PROCESS: UNDERWAY" status that have at least four check-in messages sent to the Finisher with no responses, the system will not send a fifth check-in (after 8 weeks), but will mark the Assignment "Unresponsive" status and the Project needs attention reason will be "Finisher Unresponsive".