### PR TITLE
Guard against PDFs in images by checking content type

### DIFF
--- a/app/views/manage/projects/show/_row_images.html.haml
+++ b/app/views/manage/projects/show/_row_images.html.haml
@@ -3,7 +3,7 @@
   - if value.present?
     %td
       - value.each do |image|
-        - if image.representable?
+        - if image.representable? && image.content_type.starts_with?('image')
           = link_to image_tag(image.representation( resize_to_limit: [100, 100]), class: 'thumbnail rounded'),
             url_for(image.variant(format: :jpg)), target: "_blank", class: 'align-top'
         - else


### PR DESCRIPTION
I found a project in my dev environment throwing an error if there was a PDF where an image was expected. Since `ActiveStorage` has content types I just added check. In the refactor in #389 the image display all runs through the same partial so it was a small fix.