### PR TITLE
Project Details Redesign Followup

### DIFF
--- a/app/models/concerns/loose_ends_searchable.rb
+++ b/app/models/concerns/loose_ends_searchable.rb
@@ -269,32 +269,30 @@ module LooseEndsSearchable
     end
 
     def with_sort_and_distinct(query, sort)
-      custom_sorts = {
-        "name" => "LOWER(#{_sort_name_field}) ASC",
-        "name asc" => "LOWER(#{_sort_name_field}) ASC",
-        "name desc" => "LOWER(#{_sort_name_field}) DESC",
-        "date" => "#{_since_field} ASC",
-        "date asc" => "#{_since_field} ASC",
-        "date desc" => "#{_since_field} DESC"
-      }
-
       sort_clause = sort_clause(sort)
       sort_col = sort_clause.split(" ").first
 
-      query.order(sort_clause).select("#{table_name}.*, #{table_name}.#{sort_col} AS sort_col").distinct
+      query.order(sort_clause).select("#{table_name}.*, #{sort_col} AS sort_col").distinct
     end
 
     def sort_clause(sort)
       custom_sorts = {
-        "name" => "LOWER(#{_sort_name_field}) ASC",
-        "name asc" => "LOWER(#{_sort_name_field}) ASC",
-        "name desc" => "LOWER(#{_sort_name_field}) DESC",
-        "date" => "#{_since_field} ASC",
-        "date asc" => "#{_since_field} ASC",
-        "date desc" => "#{_since_field} DESC"
+        "name" => "LOWER(#{table_name}.#{_sort_name_field}) ASC",
+        "name asc" => "LOWER(#{table_name}.#{_sort_name_field}) ASC",
+        "name desc" => "LOWER(#{table_name}.#{_sort_name_field}) DESC",
+        "date" => "#{table_name}.#{_since_field} ASC",
+        "date asc" => "#{table_name}.#{_since_field} ASC",
+        "date desc" => "#{table_name}.#{_since_field} DESC"
       }
-      # Form passed in something custom, so just use it
-      return sort if sort.present? && custom_sorts[sort].nil?
+      if sort.present? && custom_sorts[sort].nil?
+        # Form passed in something custom, so just use it
+
+        # Table name included in sort, use it as is
+        return sort if sort.include?(".")
+
+        # Table name not included in sort, add it
+        return "#{table_name}.#{sort}"
+      end
 
       sort.present? ? custom_sorts[sort] : custom_sorts[_default_sort]
     end

--- a/app/models/concerns/loose_ends_searchable.rb
+++ b/app/models/concerns/loose_ends_searchable.rb
@@ -96,7 +96,8 @@ module LooseEndsSearchable
       query = with_user_fields(query, params) if self == User
       query = with_finisher_fields(query, params) if self == Finisher
       query = with_project_fields(query, params) if self == Project
-      with_sort(query, params[:sort])
+      query = with_sort(query, params[:sort])
+      query.distinct
     end
 
     private

--- a/app/views/manage/projects/show.html.haml
+++ b/app/views/manage/projects/show.html.haml
@@ -15,10 +15,10 @@
   .col-md-8.order-last.order-md-first
     .d-flex.flex-wrap.gap-4
       = render partial: 'manage/projects/show/owner_manager'
-      = render partial: 'manage/projects/show/attributes'
       = render partial: 'manage/projects/show/details'
       = render partial: 'manage/projects/show/materials'
       = render partial: 'manage/projects/show/crafter'
+      = render partial: 'manage/projects/show/attributes'
   .col-md-4.border-start
     - if current_user.can_manage?
       = link_to 'Edit Project', [:edit, :manage, @project], class: 'btn btn-outline-secondary mb-4'

--- a/app/views/manage/projects/show/_details.html.haml
+++ b/app/views/manage/projects/show/_details.html.haml
@@ -11,4 +11,5 @@
           = render partial: 'manage/projects/show/row', locals: { title: 'Address', value: false }
         - else
           = render partial: 'manage/projects/show/row', locals: { title: 'Address', value: @project.full_address, link: link_to(fa_icon('map'), "https://maps.google.com/?q=#{@project.full_address}", target: "_blank") }
+        = render partial: 'manage/projects/show/row_images', locals: { title: 'Project Images', value: @project.project_images }
         = render partial: 'manage/projects/show/row', locals: { title: 'More Details', value: @project.more_details }

--- a/app/views/manage/projects/show/_details.html.haml
+++ b/app/views/manage/projects/show/_details.html.haml
@@ -11,5 +11,4 @@
           = render partial: 'manage/projects/show/row', locals: { title: 'Address', value: false }
         - else
           = render partial: 'manage/projects/show/row', locals: { title: 'Address', value: @project.full_address, link: link_to(fa_icon('map'), "https://maps.google.com/?q=#{@project.full_address}", target: "_blank") }
-        = render partial: 'manage/projects/show/row', locals: { title: 'Phone Number', value: @project.phone_number }
         = render partial: 'manage/projects/show/row', locals: { title: 'More Details', value: @project.more_details }

--- a/app/views/manage/projects/show/_notes.html.haml
+++ b/app/views/manage/projects/show/_notes.html.haml
@@ -3,5 +3,5 @@
   .card-body
     #note_form
       = render partial: 'manage/notes/form', locals: { project: @project }
-    #manager-notes.d-flex.flex-column
+    #manager-notes.d-flex.flex-column.d-flex.flex-wrap.gap-4
       = render partial: "manage/notes/manager_note", collection: @project.notes.order(created_at: :desc)

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -51,6 +51,18 @@ module Manage
       assert_operator(projects[0].created_at, :<, projects[1].created_at)
     end
 
+    test "index shows projects with multiple finishers only once" do
+      sign_in @user
+      @project.assignments.create!(creator: @user, finisher: Finisher.first)
+
+      assert_equal(2, @project.assignments.count)
+
+      get "/manage/projects"
+
+      assert_response :success
+      assert_select "a[href=?]", manage_project_path(@project), count: 1
+    end
+
     test "CSV export metadata" do
       sign_in @user
 
@@ -150,7 +162,9 @@ module Manage
       @project = Project.first
       sign_in @user
 
-      patch "/manage/projects/#{@project.id}.turbo_stream", params: { project: { needs_attention: "finisher_unresponsive" } }
+      patch "/manage/projects/#{@project.id}.turbo_stream",
+            params: { project: { needs_attention: "finisher_unresponsive" } }
+
       assert_match "<span class='update-flash visible'>SAVED</span>", response.body
     end
 


### PR DESCRIPTION
It turns out #389 was just too big and created some fallout. This follow up fixes the issues reported after deploy:

1. Duplicate project search results: The change from `joins` to `left_outer_joins` to handle Projects with _no_ assignments better ended up causing one result per assignment if there were multiple. I fixed this using `.distinct` but because of the sorting logic it was a little more complex (see `loose_ends_searchable.rb`) 
    * This had good tests that helped my catch the complexity 🙌 
3. Reorder the project detail sections to move attributes to the bottom
4. Add `project_images`: I somehow in double checking for missing items during #389 I think misread `pattern_files` as but itself _and_ `project_images`
5. Remove duplicate project phone number display (where `project_images` should have been 🤦 )
6. Fix the spacing between multiple assignees on the project details page

Once reviewed I'll deploy this to production