### PR TITLE
Make bootstrap available in JS to fix issues with Popover use

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+window.bootstrap = bootstrap
 import "trix"
 import "@rails/actiontext"
 import "chartkick/chart.js"


### PR DESCRIPTION
I broke this in #387 when I found two versions of Bootstrap JS. It turns out our bundled Bootstrap included it already and we were loading it. I removed the extra load without finding the error it created. This change makes `window.bootstrap` (aka `bootstrap`) available via JS throughout the site instead of only within JS modules. This will fix the popovers not working when viewing finisher notes on the manager dashboard.