### PR TITLE
Add a "working" status to the Assignment model

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -37,7 +37,7 @@ class Assignment < ApplicationRecord
   CHECK_IN_INTERVAL = 2.weeks
   UNRESPONSIVE_INTERVAL = 8.weeks
   MISSED_CHECK_INS = 4
-  CHECK_IN_STATUSES = STATUSES.values_at(:accepted, :working).freeze
+  ACTIVE_STATUSES = STATUSES.values_at(:accepted, :working).freeze
 
   belongs_to :project, touch: true
   belongs_to :finisher
@@ -58,14 +58,14 @@ class Assignment < ApplicationRecord
 
   def self.needs_check_in
     active.joins(:project)
-          .where(status: CHECK_IN_STATUSES)
+          .where(status: ACTIVE_STATUSES)
           .where(project: { status: Project::STATUSES[:in_process_underway] })
           .where("last_contacted_at < ? OR last_contacted_at IS NULL", CHECK_IN_INTERVAL.ago)
           .where("check_in_sent_at < ? OR check_in_sent_at IS NULL", CHECK_IN_INTERVAL.ago)
   end
 
   def missed_check_ins?
-    return false unless CHECK_IN_STATUSES.include?(status) &&
+    return false unless ACTIVE_STATUSES.include?(status) &&
                         project.status == Project::STATUSES[:in_process_underway] &&
                         last_contacted_at < UNRESPONSIVE_INTERVAL.ago
 

--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -74,7 +74,7 @@ class Finisher < ApplicationRecord
   has_many_attached :finished_projects
 
   has_many :active_assignments, lambda {
-    where(status: %w[invited accepted unresponsive])
+    where(status: Assignment::ACTIVE_STATUSES + %w[invited unresponsive])
   }, class_name: "Assignment"
 
   has_many :assignments, dependent: :destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,7 +92,7 @@ class Project < ApplicationRecord
 
   BOOLEAN_ATTRIBUTES = %i[joann_helped urgent influencer group_project press privacy_needed].freeze
 
-  NEEDS_ATTENTION_REASONS = %w(negative_sentiment finisher_unresponsive manager_hold)
+  NEEDS_ATTENTION_REASONS = %w[negative_sentiment finisher_unresponsive manager_hold]
 
   include LooseEndsSearchable
   include EmailAddressable
@@ -175,7 +175,7 @@ class Project < ApplicationRecord
   end
 
   def active_assignment
-    assignments.find_by(status: "accepted")
+    assignments.find_by(status: Assignment::ACTIVE_STATUSES)
   end
 
   def active_finisher

--- a/app/views/manage/projects/show/_finishers.html.haml
+++ b/app/views/manage/projects/show/_finishers.html.haml
@@ -5,7 +5,7 @@
       = link_to 'Search', [:manage, @project, :finishers, { state: @project.state, country: @project.country }], class: 'btn btn-sm btn-link'
       - if @project.state.present? && @project.country.present?
         = link_to 'Map', [:map, :manage, @project, :finishers, { near: @project.full_address, radius: 50 }], class: 'btn btn-sm btn-link'
-  .card-body
+  .card-body.d-flex.flex-wrap.gap-3
     - if @project.assignments.any?
       = render partial: 'manage/assignments/assignment', collection: @project.assignments.order(updated_at: :desc), as: :assignment, locals: { context: :project }
     - else

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -76,15 +76,18 @@ class ProjectTest < ActiveSupport::TestCase
   test "All fixtures should be valid" do
     Project.find_each do |project|
       project.save
+
       assert_predicate(project, :valid?, "Project fixture is invalid. Errors: #{project.errors.inspect}")
     end
   end
 
   test "needing_attention scope" do
     Project.first.update(needs_attention: "manager_hold")
+
     assert_equal 1, Project.needing_attention.count
 
     Project.first.update(needs_attention: "")
+
     assert_equal 0, Project.needing_attention.count
   end
 
@@ -95,6 +98,7 @@ class ProjectTest < ActiveSupport::TestCase
 
   test "finisher method returns last finisher" do
     @project.assignments.create!(creator: User.new, finisher: finishers(:crocheter))
+
     assert_not_nil @project.finisher
     assert_equal finishers(:crocheter), @project.finisher
   end
@@ -102,6 +106,14 @@ class ProjectTest < ActiveSupport::TestCase
   test "active_finisher method returns finisher" do
     assert_not_nil @project.active_finisher
     assert_equal finishers(:knitter), @project.active_finisher
+  end
+
+  test "active_finisher includes assignments in working status" do
+    assignment = @project.active_assignment
+    assignment.update!(status: Assignment::STATUSES[:working])
+    @project.reload
+
+    assert_not_nil @project.active_finisher
   end
 
   test "ignore_inactive scope" do
@@ -117,10 +129,12 @@ class ProjectTest < ActiveSupport::TestCase
 
   test "inbound_email_address assignment" do
     p = Project.new
-    refute p.inbound_email_address
+
+    assert_not p.inbound_email_address
     p.valid?
-    assert_match /^project-\w{#{EmailAddressable::LENGTH}}@#{EmailAddressable::DESTINATION_HOST}/,
-      p.inbound_email_address
+
+    assert_match(/^project-\w{#{EmailAddressable::LENGTH}}@#{EmailAddressable::DESTINATION_HOST}/o,
+                 p.inbound_email_address)
   end
 
   test "Name update" do
@@ -166,9 +180,9 @@ class ProjectTest < ActiveSupport::TestCase
 
   test "needs_attention_option returns proper struct" do
     assert_equal [["Negative Sentiment", "negative_sentiment"],
-      ["Finisher Unresponsive", "finisher_unresponsive"],
-      ["Manager Hold", "manager_hold"]],
-      Project.needs_attention_options
+                  ["Finisher Unresponsive", "finisher_unresponsive"],
+                  ["Manager Hold", "manager_hold"]],
+                 Project.needs_attention_options
   end
 
   test "missing_address_information? helper" do
@@ -228,7 +242,8 @@ class ProjectTest < ActiveSupport::TestCase
   test "responds to finisher_notes" do
     assignment = @project.assignments.create(creator: User.new, finisher: finishers(:crocheter))
     assignment.notes.create!(sentiment: "going_well",
-      text: "Here's some text", user_id: finishers(:crocheter).id)
+                             text: "Here's some text", user_id: finishers(:crocheter).id)
+
     assert_equal "Here's some text", @project.finisher_notes.first.text
   end
 


### PR DESCRIPTION
As [requested in this Slack list item](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08M6NRG001) this PR adds a new `working` status to the Assignment model. This was a little more complicated because we had a few places using `accepted` to indicate active.

Since this complicated the `needs_check_in` query with an IN clause I refactored it a little for clarity. I also updated the Project and Finisher helper methods that were using Assignment status information. There is some other Rubocop corrections here as well.