### PR TITLE
Assignment delete support (aka unmatch)

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -219,7 +219,18 @@ h1.project-name
   #project-status-select
     font-weight: bold
 
+
+.unmatch-button
+  border: none
+  opacity: 0.6
+  font-size: .75rem
+
+  &:hover
+    opacity: 1
+
 .assignment-card
+  margin-bottom: 0.5rem
+
   i.fa
     color: $secondary
     width: 1.3rem

--- a/app/views/manage/assignments/_assignment.html.haml
+++ b/app/views/manage/assignments/_assignment.html.haml
@@ -1,4 +1,4 @@
 
-.d-inline-block.border.rounded.p-2.w-100
-  %turbo-frame{ id: dom_id(assignment) }
+%turbo-frame{ id: dom_id(assignment) }
+  .d-inline-block.border.rounded.p-2.w-100
     = render "manage/assignments/assignment_form", assignment: assignment, readonly: local_assigns[:readonly], context: local_assigns[:context]

--- a/app/views/manage/assignments/_assignment_form.html.haml
+++ b/app/views/manage/assignments/_assignment_form.html.haml
@@ -1,3 +1,5 @@
+= button_to [:manage, assignment], method: :delete, class: 'unmatch-button float-end btn btn-sm btn-outline-danger rounded-circle', form: { data: { turbo_confirm: 'Deleting assignment. Are you sure?' } } do
+  = fa_icon("trash", title: 'Unmatch')
 = form_for [:manage, assignment] do |form|
   %ul.list-unstyled.assignment-card
     - if local_assigns[:context] != :project


### PR DESCRIPTION
Allow the manager to delete an Assignment from the Project or Finisher view of the Assignment card. This is also called "unmatch" in some discussions. I added this via Turbo request along with a confirmation since it can't be undone.

See also: [Slack list item](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08LG52HL9M)

## Video of feature

https://github.com/user-attachments/assets/1edbf46f-e531-46a1-8326-c6d90effa041

