### PR TITLE
Allow project search sort by last_contacted_at

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -11,7 +11,10 @@ module Manage
 
     def index
       @title = "Loose Ends - Manage - Projects"
-      @projects = Project.search(params).includes(:finishers)
+      @projects = Project.search(params)
+                         .includes(:finishers)
+                         .left_outer_joins(:assignments)
+                         .group("projects.id")
 
       respond_to do |format|
         format.csv { add_csv_headers }

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -15,7 +15,7 @@
         %tr.small
           %th.sortable{ data: { sort: "name asc", reverse: "name desc" } } Project Name
           %th.sortable{ data: { sort: "status asc", reverse: "status desc" } } Status
-          %th.text-nowrap Last Finisher Response
+          %th.sortable.text-nowrap{ data: { sort: "MAX(assignments.last_contacted_at) asc NULLS LAST", reverse: "MAX(assignments.last_contacted_at) desc NULLS LAST" } } Last Finisher Response
           %th.sortable{ data: { sort: "users.email asc", reverse: "users.email desc" } } Project Owner
           %th.sortable{ data: { sort: "finishers.chosen_name asc nulls last", reverse: "finishers.chosen_name desc nulls last" } } Finisher
       %tbody

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -51,6 +51,14 @@ module Manage
       assert_operator(projects[0].created_at, :<, projects[1].created_at)
     end
 
+    test "index sort accepts MAX(assignments.last_contacted_at)" do
+      sign_in @user
+      get "/manage/projects?sort=MAX(assignments.last_contacted_at)+asc"
+      projects = assigns(:projects)
+
+      assert_equal Project.all.count, projects.to_a.size
+    end
+
     test "index shows projects with multiple finishers only once" do
       sign_in @user
       @project.assignments.create!(creator: @user, finisher: Finisher.first)


### PR DESCRIPTION
Make the "Last Finisher Response" field on the project search list view sortable. This was the only column not yet searchable because it required a more complex query. I sorted out the join/max query in the PR and added it.

See Also: [Slack list item](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08NA0J48N6)