### PR TITLE
Validate Note on Finisher check-in response

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -21,8 +21,7 @@ class AssignmentsController < AuthenticatedController
     if @note.save
       redirect_to thank_you_path
     else
-      render :check_in, status: :unprocessable_entity,
-        flash: { alert: "Something went wrong. Contact support." }
+      render :check_in, status: :unprocessable_entity
     end
   end
 
@@ -33,7 +32,7 @@ class AssignmentsController < AuthenticatedController
 
     def sanitize_params
       @assignment_id = params.expect(:id)
-      @note_params = params.expect(note: [:sentiment, :text])
+      @note_params = params.require(:note).permit(:sentiment, :text)
     end
 
     def alert_manager

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -66,13 +66,9 @@ class Assignment < ApplicationRecord
   end
 
   def missed_check_ins?
-    return false unless status == STATUSES[:accepted] &&
+    (status == STATUSES[:accepted] &&
       project.status == Project::STATUSES[:in_process_underway] &&
-      last_contacted_at < UNRESPONSIVE_INTERVAL.ago
-
-    check_ins = notes.order(created_at: :desc).limit(MISSED_CHECK_INS)
-    return false unless check_ins.count == MISSED_CHECK_INS
-    true
+      last_contacted_at < UNRESPONSIVE_INTERVAL.ago) ? true : false
   end
 
   def name

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -40,9 +40,15 @@ class Note < ApplicationRecord
   belongs_to :user
 
   before_create :set_visibility
-  after_create :flag_project
+
+  validates :sentiment, presence: true, if: :finisher_note?
+  validates :text, presence: { message: "is required for 'Need Help' responses" }, if: :negative?
 
   scope :for_assignment, -> { where(notable_type: 'Assignment') }
+
+  def finisher_note?
+    notable_type == "Assignment"
+  end
 
   def negative?
     return false unless sentiment.present? && SENTIMENTS[sentiment].present?
@@ -50,12 +56,6 @@ class Note < ApplicationRecord
   end
 
   private
-
-    # Set project.needs_attention = true for negative sentiments
-    #
-    def flag_project
-      # if notable is Assignment and sentiment is alert, set project.needs_attention
-    end
 
     # TODO probably don't need this b/c visibility
     # is determined by notable_type

--- a/app/views/assignments/check_in.html.haml
+++ b/app/views/assignments/check_in.html.haml
@@ -1,3 +1,5 @@
+= render partial: "error_messages", locals: { resource: @note }
+
 .row
   .col-6
     %h3 Hello, #{@note.notable.finisher.name}
@@ -11,10 +13,10 @@
       - Note::SENTIMENTS.keys.map do |key|
         .pt-3.form-check.form-check-inline
           = f.radio_button :sentiment, key, class: "radio"
-          = f.label "headline_#{key}".to_sym, key.titleize
+          = f.label "sentiment_#{key}".to_sym, key.titleize
 
       .pt-6 &nbsp;
       .fw-bold Leave an optional note for your Project Manager
-      = f.text_area :text, size: "50x4"
+      = f.text_area :text, size: "50x4", id: "note_text"
 
       .pt-3= f.submit "Submit", class: "btn btn-primary"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,6 +10,11 @@ require "test_helper"
 # Locators: https://www.selenium.dev/documentation/webdriver/elements/locators/
   # XPath: https://www.geeksforgeeks.org/introduction-to-xpath/
 
+Capybara.configure do |config|
+  config.save_path = Rails.root.join("tmp", "screenshots")
+end
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome
+  include Devise::Test::IntegrationHelpers
 end

--- a/test/controllers/assignments_controller_test.rb
+++ b/test/controllers/assignments_controller_test.rb
@@ -48,4 +48,18 @@ class AssignmentsControllerTest < ActionDispatch::IntegrationTest
     get "/assignment/#{@assignment.id}/check_in"
     assert_redirected_to "/users/sign_in"
   end
+
+  test "must have sentiment, text not required unless need_help" do
+    post "/assignment/#{@assignment.id}/check_in", params: { note: { sentiment: "going_well" }}
+    assert_redirected_to "/thank_you"
+
+    post "/assignment/#{@assignment.id}/check_in", params: { note: {}}
+    assert_response :bad_request
+
+    post "/assignment/#{@assignment.id}/check_in", params: { note: { text: "text" }}
+    assert_response :unprocessable_content
+
+    post "/assignment/#{@assignment.id}/check_in", params: { note: { sentiment: "need_help", text: "" }}
+    assert_response :unprocessable_content
+  end
 end

--- a/test/jobs/send_check_ins_job_test.rb
+++ b/test/jobs/send_check_ins_job_test.rb
@@ -43,10 +43,6 @@ class SendCheckInsJobTest < ActiveJob::TestCase
   test "escalate unresponsive" do
     @assignment = Assignment.find(1)
     user = @assignment.finisher.user
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 8.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 6.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 4.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 2.weeks, user: user)
     @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
     @assignment.update_attribute(:last_contacted_at,
       Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_INTERVAL)

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -83,10 +83,6 @@ class AssignmentTest < ActiveSupport::TestCase
 
   test "missed_check_ins?" do
     user = @assignment.finisher.user
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 8.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 6.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 4.weeks, user: user)
-    @assignment.notes.create!(created_at: Time.now.beginning_of_day - 2.weeks, user: user)
     @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
     @assignment.update_attribute(:last_contacted_at,
       Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_INTERVAL)
@@ -97,7 +93,6 @@ class AssignmentTest < ActiveSupport::TestCase
     refute @assignment.missed_check_ins?
     @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
 
-    @assignment.notes.last.destroy
     travel_to 2.weeks.ago
     refute @assignment.missed_check_ins?
   end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -53,6 +53,25 @@ class NoteTest < ActiveSupport::TestCase
     assert_equal "All good!", assignment_notes.first.text
   end
 
+  test "requires sentiment for Assignment note" do
+    note = Assignment.first.notes.new sentiment: "going_well", text: "", user: users(:finisher)
+    assert note.valid?
+
+    note = Assignment.first.notes.new text: "no sentiment", user: users(:finisher)
+    assert_not note.valid?
+
+    note = Assignment.first.notes.new sentiment: "", text: "no sentiment", user: users(:finisher)
+    assert_not note.valid?
+  end
+
+  test "requires text for negative note" do
+    note = Assignment.first.notes.new sentiment: "need_help", text: "", user: users(:finisher)
+    assert_not note.valid?
+
+    note = Assignment.first.notes.new sentiment: "need_help", text: "this sux", user: users(:finisher)
+    assert note.valid?
+  end
+
   test "#negative?" do
     n = Assignment.first.notes.new(sentiment: "going_well")
     refute n.negative?


### PR DESCRIPTION
Check-in form allowed null Note params.  A null `sentiment` on a Note of `notable_type == "Assignmment"` breaks views.  Also added a validation that a Note of sentiment "need_help" (negative response) requires a :text param.