### PR TITLE
Handle nil last_contacted_at in Assignment#missed_check_ins?

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -68,7 +68,7 @@ class Assignment < ApplicationRecord
   def missed_check_ins?
     (status == STATUSES[:accepted] &&
       project.status == Project::STATUSES[:in_process_underway] &&
-      last_contacted_at < UNRESPONSIVE_INTERVAL.ago) ? true : false
+      (last_contacted_at.present? && last_contacted_at < UNRESPONSIVE_INTERVAL.ago)) ? true : false
   end
 
   def name

--- a/test/models/assignment_test.rb
+++ b/test/models/assignment_test.rb
@@ -83,17 +83,26 @@ class AssignmentTest < ActiveSupport::TestCase
 
   test "missed_check_ins?" do
     user = @assignment.finisher.user
+
+    # With proper Project status and last_contacted_at prior to UNRESPONSIVE_INTERVAL.ago
     @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
     @assignment.update_attribute(:last_contacted_at,
       Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_INTERVAL)
-
     assert @assignment.missed_check_ins?
 
-    @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_connected])
-    refute @assignment.missed_check_ins?
-    @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_underway])
-
+    # Not prior to UNRESPONSIVE_INTERVAL.ago
     travel_to 2.weeks.ago
+    refute @assignment.missed_check_ins?
+    travel_back
+
+    # With nil last_contacted_at
+    @assignment.update_attribute(:last_contacted_at, nil)
+    refute @assignment.missed_check_ins?
+
+    # With irrelevant Project status
+    @assignment.project.update_attribute(:status, Project::STATUSES[:in_process_connected])
+    @assignment.update_attribute(:last_contacted_at,
+      Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_INTERVAL)
     refute @assignment.missed_check_ins?
   end
 


### PR DESCRIPTION
`assignment.last_contacted_at` starts out nil.  The logic in `Assignment#missed_check_ins?` did not take this into account, breaking SendCheckInsJob