### PR TITLE
Sharing details about crafter online now defaults to true

### DIFF
--- a/db/migrate/20250523002151_set_default_crafter_details.rb
+++ b/db/migrate/20250523002151_set_default_crafter_details.rb
@@ -1,0 +1,5 @@
+class SetDefaultCrafterDetails < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :projects, :can_share_crafter_details, from: false, to: true
+  end
+end


### PR DESCRIPTION
Created migration file which switches can_share_crafter_details project boolean to default to true. This will auto-check the "Yes, it is OK to share details about the crafter online" message when submitting a new project

![image](https://github.com/user-attachments/assets/e422e389-b88c-4c08-aae0-4709a0a062ba)

Slack item: [Make sharing original crafter details an opt-out instead of opt-in](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec08LG46AQNB)
