### PR TITLE
Add 'completed' option to finisher checkins

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -36,7 +36,7 @@ class AssignmentsController < AuthenticatedController
     end
 
     def alert_manager
-      return unless @note.negative?
+      return unless @note.alert_manager?
 
       set_project_needs_attention
       ProjectMailer.with(resource: @note.notable).alert_manager.deliver_later

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -14,7 +14,7 @@ class AssignmentsController < AuthenticatedController
 
   # POST /assignment/:id/check_in
   def record_check_in
-    assignment = current_user.finisher. assignments.find(@assignment_id)
+    assignment = current_user.finisher.assignments.find(@assignment_id)
     @note = assignment.notes.new(@note_params)
     @note.user_id = current_user.id
 
@@ -47,6 +47,12 @@ class AssignmentsController < AuthenticatedController
     end
 
     def set_project_needs_attention
-      @note.notable.project.update!(needs_attention: 'negative_sentiment')
+      reason = if @note.negative?
+                'negative_sentiment'
+              else
+                'completed'
+              end
+
+      @note.notable.project.update!(needs_attention: reason)
     end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -33,6 +33,10 @@ class Note < ApplicationRecord
     "no_progress" => {
       classification: "neutral",
       alert_manager: false
+    },
+    "completed" => {
+      classification: "positive",
+      alert_manager: true
     }
   }
 
@@ -53,6 +57,11 @@ class Note < ApplicationRecord
   def negative?
     return false unless sentiment.present? && SENTIMENTS[sentiment].present?
     SENTIMENTS[sentiment][:classification] == "negative"
+  end
+
+  def alert_manager?
+    return false unless sentiment.present? && SENTIMENTS[sentiment].present?
+    SENTIMENTS[sentiment][:alert_manager]
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,7 +92,7 @@ class Project < ApplicationRecord
 
   BOOLEAN_ATTRIBUTES = %i[joann_helped urgent influencer group_project press privacy_needed].freeze
 
-  NEEDS_ATTENTION_REASONS = %w(negative_sentiment finisher_unresponsive manager_hold)
+  NEEDS_ATTENTION_REASONS = %w(negative_sentiment finisher_unresponsive manager_hold completed)
 
   include LooseEndsSearchable
   include EmailAddressable

--- a/app/views/assignments/check_in.html.haml
+++ b/app/views/assignments/check_in.html.haml
@@ -1,7 +1,7 @@
 = render partial: "error_messages", locals: { resource: @note }
 
 .row
-  .col-6
+  .col-8
     %h3 Hello, #{@note.notable.finisher.name}
 
     .p Thank you for being a Loose Ends volunteer! Please provide an update on your project. There is NO DEADLINE on your work - any pace is fine - but we do need to hear from you regularly with an update. If you check Need Help, your Loose Ends project manager will be in touch.

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -167,7 +167,8 @@ class ProjectTest < ActiveSupport::TestCase
   test "needs_attention_option returns proper struct" do
     assert_equal [["Negative Sentiment", "negative_sentiment"],
       ["Finisher Unresponsive", "finisher_unresponsive"],
-      ["Manager Hold", "manager_hold"]],
+      ["Manager Hold", "manager_hold"],
+      ["Completed", "completed"]],
       Project.needs_attention_options
   end
 


### PR DESCRIPTION
Per [this request in Slack](https://looseendsproject.slack.com/archives/C066WSK1X46/p1748439137873289):

> We need to add DONE as an option in the auto generated check-in email. Right now people can only choose GOING WELL, NO PROGRESS, or NEED HELP. I've had folks mark GOING WELL and in the notes say they are done with the project.

This adds the status as `completed` to be clear the intent. The change was pretty minor but required some changes to Project#needs_attention as well. I added tests to go along with this. With four options the page was getting tight to I widened the content area a bit, like so:

![New finisher checkin page](https://github.com/user-attachments/assets/8b1a40cd-72f4-4ea5-8822-9285b2ab7da0)

