### PR TITLE
Add "etc" to description of craft options

### DIFF
--- a/app/views/application/_project_form_fields.html.haml
+++ b/app/views/application/_project_form_fields.html.haml
@@ -14,7 +14,7 @@
     = form.label :craft_type, 'What type of craft?', class: 'form-label required'
   .col-md-4
     = form.text_field :craft_type, class: 'form-control', required: true
-    .form-info Knit, Crochet, Quilt. If you do not know, say "I don't know."
+    .form-info Knit, Crochet, Quilt, etc. If you do not know, say "I don't know."
 .row.mb-4
   .col-md-4
     = form.label :append_project_images, 'Project Images', class: 'form-label required'


### PR DESCRIPTION
Description:
The helper text of "What type of craft?" currently reads "Knit, Crochet, Quilt. If you do not know, say "I don't know."" There should be an "etc" in the list so that people don't think it has to be one of those three. It should be updated to read "Knit, Crochet, Quilt, etc. If you do not know, say "I don't know.""

Before:
<img width="1470" alt="Screenshot 2025-06-02 at 6 41 44 PM" src="https://github.com/user-attachments/assets/bf80479c-1c0f-4961-8767-36604f2fb007" />

After:
<img width="1470" alt="Screenshot 2025-06-02 at 6 41 58 PM" src="https://github.com/user-attachments/assets/505c6973-c3b4-430d-899f-c5a841ca6d02" />
