### PR TITLE
Capybara Local Runner Configuration for Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bullseye
+FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
 # The value is a comma-separated list of allowed domains
@@ -6,10 +6,11 @@ ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.git
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends imagemagick postgresql-client\
+    && apt-get -y install --no-install-recommends imagemagick postgresql-client \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this line to install additional gems.
 RUN su vscode -c "gem install foreman"
+
 # Install heroku CLI
 RUN su vscode -c "curl https://cli-assets.heroku.com/install-ubuntu.sh | sh"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,16 +1,34 @@
 FROM mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm
 
-# Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
-# The value is a comma-separated list of allowed domains
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.preview.app.github.dev,.app.github.dev"
 
-# [Optional] Uncomment this section to install additional OS packages.
+# Install required OS packages, including Chromium & Chromedriver for Selenium tests
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends imagemagick postgresql-client \
+    && apt-get -y install --no-install-recommends \
+        chromium \
+        chromium-driver \
+        direnv \
+        fonts-liberation \
+        imagemagick \
+        libasound2 \
+        libnss3 \
+        libx11-xcb1 \
+        libxss1 \
+        postgresql-client \
+        x11-utils \
+        xauth \
+        xvfb \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# [Optional] Uncomment this line to install additional gems.
+# Create a symlink from 'chromium' to 'google-chrome' to satisfy tools expecting Chrome binary
+RUN ln -sf /usr/bin/chromium /usr/bin/google-chrome
+
+# Set environment variable for Chrome binary path (used by some test tools)
+ENV CHROME_BIN=/usr/bin/chromium
+
+# Install foreman gem (run as vscode user)
 RUN su vscode -c "gem install foreman"
 
-# Install heroku CLI
+# Install Heroku CLI (run as vscode user)
+# Do this last as if it fails it will not break the devcontainer build
 RUN su vscode -c "curl https://cli-assets.heroku.com/install-ubuntu.sh | sh"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,11 @@
 		}
 	},
 
+	"containerEnv": {
+		"SELENIUM_HOST": "selenium",
+		"SELENIUM_PORT": "4444"
+	},
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,8 +1,15 @@
 services:
   app:
+    depends_on:
+      - db
+      - selenium
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+    environment:
+      WEB_CONCURRENCY: 1
+      SELENIUM_HOST: selenium
+      SELENIUM_PORT: 4444
 
     volumes:
       - ../..:/workspaces:cached
@@ -13,9 +20,12 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  selenium:
+    image: seleniarm/standalone-chromium
+    restart: unless-stopped
 
+  # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+  # (Adding the "ports" property to this file will not forward from a Codespace.)
   db:
     image: postgres:latest
     restart: unless-stopped

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -17,6 +17,14 @@ jobs:
     needs: install-cache
     timeout-minutes: 10
     services:
+      selenium:
+        image: seleniarm/standalone-chromium
+        ports: ["4444:4444"]
+        options: >-
+          --health-cmd "curl -f http://localhost:4444/wd/hub/status || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       postgres:
         image: postgres
         ports: ["5432:5432"]

--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,6 @@ group :test do
   gem "capybara"
   gem "rails-controller-testing"
   gem "selenium-webdriver"
-  gem "webdrivers"
 end
 
 gem "solid_queue", "~> 1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ gem "bootsnap", require: false
 gem "sassc-rails"
 
 # Create inline-styled emails from regular CSS file
-gem 'premailer-rails'
+gem "premailer-rails"
 
 # Validations for uploads
 gem "active_storage_validations", ">= 2.0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -553,10 +553,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -628,7 +624,6 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
   will_paginate (~> 4)
 
 RUBY VERSION

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,13 +8,13 @@ require "test_helper"
 # Cheatsheet: https://devhints.io/capybara
 
 # Locators: https://www.selenium.dev/documentation/webdriver/elements/locators/
-  # XPath: https://www.geeksforgeeks.org/introduction-to-xpath/
+# XPath: https://www.geeksforgeeks.org/introduction-to-xpath/
 
 Capybara.configure do |config|
-  config.save_path = Rails.root.join("tmp", "screenshots")
+  config.save_path = Rails.root.join("tmp/screenshots")
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome
+  driven_by :selenium, using: :remote_selenium, screen_size: [1280, 800]
   include Devise::Test::IntegrationHelpers
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -15,6 +15,6 @@ Capybara.configure do |config|
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :remote_selenium, screen_size: [1280, 800]
+  driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: { browser: :remote, url: "http://chrome-server:4444" }
   include Devise::Test::IntegrationHelpers
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -12,9 +12,12 @@ require "test_helper"
 
 Capybara.configure do |config|
   config.save_path = Rails.root.join("tmp/screenshots")
+  config.always_include_port = true
 end
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: { browser: :remote, url: "http://chrome-server:4444" }
+  driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: {
+    browser: :remote, url: "http://selenium:4444"
+  }
   include Devise::Test::IntegrationHelpers
 end

--- a/test/controllers/manage/inbound_emails_controller_test.rb
+++ b/test/controllers/manage/inbound_emails_controller_test.rb
@@ -10,6 +10,7 @@ module Manage
 
     test "index" do
       get "/manage/inbound_emails"
+
       assert_response :success
     end
   end


### PR DESCRIPTION
Capybara tries to run as part of `overcommit`. However, there was no container or installed copy of chrome for it to connect to and run tests with. 

This is problematic for local development while running in a DevContainer. 

This PR attempts to correct that issue to allow for `overcommit` to run `rspec` and `minitests` prior to commit. 