### PR TITLE
Split Google Maps API keys into server/client

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,7 +8,10 @@ RAILS_ENV_DISPLAY="development"
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
+# Key for the Google Maps display
 GOOGLE_MAPS_API_KEY=
+# Key for the Google Maps Geocode API
+GOOGLE_MAPS_GEOCODE_API_KEY=
 
 RAILS_INBOUND_EMAIL_PASSWORD=
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -5,7 +5,7 @@ Geocoder.configure(
   lookup: :google,
 
   # to use an API key:
-  api_key: ENV['GOOGLE_MAPS_API_KEY'],
+  api_key: ENV.fetch("GOOGLE_MAPS_GEOCODE_API_KEY", nil),
   use_https: true,
 
   # geocoding service request timeout, in seconds (default 3):


### PR DESCRIPTION
Per a warning email from Google they would like our server-side geocoding and client-side mapping to use two different keys. They then want each of those two restricted. This isn't _critical_ as our maps usage is only in the manager pages and thus unlikely to leak. The steps to accomplish the requested change are:

  1. Split out existing single ENV variable into two, one for web and one for geocoding
      2. Set both config vars to the existing key value in Heroku (staging and production) - _already done_
      3. Update the code to use two ENV variables  - _this PR_
  2. Use the Google console to create a second key limited to web
      1. Limit domains as appropriate (`*.looseends.org`) 
  4. Update Heroku `GOOGLE_MAPS_API_KEY` with the second key (staging first, verify, etc)

This does not solve the IP limiting piece for the geocoding API key – Heroku IP management makes that infeasible. However, this will make it so the API key for geocoding won't be in the Maps URL. 