### PR TITLE
Include all Docker files in scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,9 @@ updates:
     # Enable version updates for Docker
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` directory
-    directory: "/"
+    directory:
+      - "/"
+      - ".devcontainer/"
     # Check for updates once a week
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Update the scanning configuration to include Dockerfiles from both the root directory and the `.devcontainer` directory.