### PR TITLE
Docker scanning requires single directory for each scanner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,18 @@ updates:
     # Enable version updates for Docker
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` directory
-    directory:
-      - "/"
-      - ".devcontainer/"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    labels:
+      - 'dependencies'
+      - 'docker'
+
+    # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: ".devcontainer/"
     # Check for updates once a week
     schedule:
       interval: "weekly"

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -49,17 +49,23 @@ jobs:
         with:
           node-version: 23.5.0
           cache: yarn
+
       - name: Bundle install
         run: |
           bundle install
+
       - name: Install packages
         run: yarn install --force
+
       - name: Yarn Build Javascript
         run: yarn build
+
       - name: Yarn Build CSS
         run: yarn build:css
+
       - name: Copy Database Config
         run: cp config/database.yml.ci config/database.yml
+
       - name: Run tests
         env:
           RAILS_ENV: test


### PR DESCRIPTION
Update the configuration to ensure that each Docker scanner operates within its own directory, improving clarity and organization in the scanning process. Additionally, streamline the update schedule for Docker dependencies.