### PR TITLE
Limit the amount of photos a finisher can upload

### DIFF
--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -99,7 +99,8 @@ class Finisher < ApplicationRecord
 
   validates :terms_of_use, acceptance: true
   validates :finished_projects, content_type: %i[png jpg jpeg webp gif],
-                                size: { greater_than_or_equal_to: 5.kilobytes }
+                                size: { greater_than_or_equal_to: 5.kilobytes },
+                                limit: { max: 5 }
   validates :picture, content_type: %i[png jpg jpeg webp gif], size: { greater_than_or_equal_to: 5.kilobytes }
 
   serialize :in_home_pets

--- a/app/views/finishers/_favorites_form.html.haml
+++ b/app/views/finishers/_favorites_form.html.haml
@@ -19,10 +19,10 @@
   .row.g-1.g-sm-4.mb-3
     .col-12.col-md-9
       = form.label "Things you've finished", class: 'form-label optional'
-      .form-info Please upload photos of things you'd like to show off!
+      .form-info Add up to 5 photos of your work. This helps us match the right projects to the right people.
       = form.file_field :append_finished_projects, class: 'form-control', accept: "image/png,image/gif,image/jpeg,image/webp",  :multiple => true
       - form.object.finished_projects.each do |image|
-        - if image.representable?
+        - if image.persisted? && image.representable?
           = image_tag image.representation( resize_to_limit: [100, 100]), class: 'thumbnail', target: '_blank'
   .row.g-1.g-sm-4.mb-3.mb-3
     .col-12.col-md-9


### PR DESCRIPTION
A finisher can already optionally add photos of their work to their profile.

There should be a maximum of 5 pictures. There should be a short description saying "(Optional) Add up to 5 photos of your work. This helps us match the right projects to the right people."

This PR adds an ActiveRecord validation on the number of files for a finisher's `finished_projects`. It also adds a check that the image is persisted before trying to render it's little thumbnail to prevent a 500 when the `finished_projects` field throws a validation error before successfully saving.