### PR TITLE
Surface can_share_crafter_details in Project manage

### DIFF
--- a/app/controllers/manage/finishers_controller.rb
+++ b/app/controllers/manage/finishers_controller.rb
@@ -16,8 +16,7 @@ module Manage
           response.headers["Content-Type"] = "text/csv"
           response.headers["Content-Disposition"] =
             "attachment; filename=#{@title.parameterize}-#{DateTime.now.strftime("%Y-%m-%d-%H%M")}.csv"
-          @finishers = Finisher.includes(:user).select(:id, :user_id, :first_name, :last_name, :email,
-                                                       :has_workplace_match).search(params)
+          @finishers = Finisher.includes(:user).search(params)
         end
         format.html do
           first_finisher = Finisher.order(:joined_on).first
@@ -48,7 +47,8 @@ module Manage
       results = Geocoder.search(params[:near])
       return unless results.first
 
-      @finishers = Finisher.geocoded.near(results.first.coordinates, params[:radius]).includes(:rated_assessments, :user)
+      @finishers = Finisher.geocoded.near(results.first.coordinates, params[:radius]).includes(:rated_assessments,
+                                                                                               :user)
       if params[:skill_id].present?
         @finishers = @finishers.joins(:assessments).where(assessments: { skill_id: params[:skill_id], rating: 1.. })
         @skill_id = params[:skill_id]

--- a/app/models/concerns/loose_ends_searchable.rb
+++ b/app/models/concerns/loose_ends_searchable.rb
@@ -272,7 +272,16 @@ module LooseEndsSearchable
       sort_clause = sort_clause(sort)
       sort_col = sort_clause.split(" ").first
 
-      query.order(sort_clause).select("#{table_name}.*, #{sort_col} AS sort_col").distinct
+      if sort_col.start_with?("MAX")
+        query.order(sort_clause)
+             .select("#{table_name}.*, #{sort_col} AS sort_col")
+             .distinct
+      else
+        query.order(sort_clause)
+             .select("#{table_name}.*, #{sort_col} AS sort_col")
+             .group("#{table_name}.id, #{sort_col}")
+             .distinct
+      end
     end
 
     def sort_clause(sort)

--- a/app/views/manage/projects/show/_crafter.html.haml
+++ b/app/views/manage/projects/show/_crafter.html.haml
@@ -6,4 +6,5 @@
         = render partial: 'manage/projects/show/row', locals: { title: 'Name', value: @project.crafter_name }
         = render partial: 'manage/projects/show/row', locals: { title: 'Description', value: @project.crafter_description }
         = render partial: 'manage/projects/show/row', locals: { title: 'Dominant Hand', value: @project.crafter_dominant_hand }
+        = render partial: 'manage/projects/show/row', locals: { title: 'Can Share', value: @project.can_share_crafter_details }
         = render partial: 'manage/projects/show/row_images', locals: { title: 'Images', value: @project.crafter_images }

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -59,6 +59,15 @@ module Manage
       assert_equal Project.all.count, projects.to_a.size
     end
 
+    test "index sort accepts email list view" do
+      sign_in @user
+      get "/manage/projects?sort=users.email+asc"
+      projects = assigns(:projects)
+
+      assert_equal Project.count, projects.to_a.size
+      assert_operator(projects[0].user.email, :<, projects[1].user.email)
+    end
+
     test "index shows projects with multiple finishers only once" do
       sign_in @user
       @project.assignments.create!(creator: @user, finisher: Finisher.first)


### PR DESCRIPTION
The `can_share_crafter_details` field was showing in the Project edit view but not the read-only view. This PR adds that. It also fixes a query issue causing [a 500 error](https://looseendsproject.slack.com/archives/C08BY414BED/p1750710202197799) when clicking on some column headers in the project and finisher searches.