### PR TITLE
Only validate finished_projects if it is updated.

### DIFF
--- a/app/models/finisher.rb
+++ b/app/models/finisher.rb
@@ -100,7 +100,8 @@ class Finisher < ApplicationRecord
   validates :terms_of_use, acceptance: true
   validates :finished_projects, content_type: %i[png jpg jpeg webp gif],
                                 size: { greater_than_or_equal_to: 5.kilobytes },
-                                limit: { max: 5 }
+                                limit: { max: 5 },
+                                if: ->(obj) { obj.attachment_changes['finished_projects'].present? }
   validates :picture, content_type: %i[png jpg jpeg webp gif], size: { greater_than_or_equal_to: 5.kilobytes }
 
   serialize :in_home_pets

--- a/test/controllers/finishers_controller_test.rb
+++ b/test/controllers/finishers_controller_test.rb
@@ -103,4 +103,18 @@ class FinishersControllerTest < ActionController::TestCase
 
     assert(finisher.has_volunteer_time_off)
   end
+
+  test "can remove finished project image over limit" do
+    finisher = finishers(:crocheter)
+    finisher.append_finished_projects = [fixture_file_upload("tiny.jpg")] * 15
+    finisher.save!(validate: false)
+
+    sign_in finisher.user
+
+    post :destroy, params: { finished_project_id: finisher.finished_projects.first.id }
+    assert_redirected_to finisher_path
+
+    finisher.reload
+    assert_equal 14, finisher.finished_projects.count
+  end
 end

--- a/test/controllers/manage/finishers_controller_test.rb
+++ b/test/controllers/manage/finishers_controller_test.rb
@@ -170,5 +170,18 @@ module Manage
 
       assert_predicate(finisher.user, :confirmed?)
     end
+
+    test "can view a finisher with too many finished_projects" do
+      sign_in @user
+
+      finisher = finishers(:crocheter)
+      finisher.inbound_email_address = nil # force show to also save
+      finisher.append_finished_projects = [fixture_file_upload("tiny.jpg")] * 15
+      finisher.save!(validate: false)
+
+      get :show, params: { id: finisher.id }
+
+      assert_response :success
+    end
   end
 end

--- a/test/models/finisher_test.rb
+++ b/test/models/finisher_test.rb
@@ -138,4 +138,17 @@ class FinisherTest < ActiveSupport::TestCase
     assert_not finisher.valid?
     assert_includes finisher.errors[:finished_projects], "too many files attached (maximum is 5 files, got 6)"
   end
+
+  test "Removing a finished project from a user with too many is allowed" do
+    image = Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_fixture_path, 'tiny.jpg'), 'image/jpeg')
+
+    finisher = finishers(:crocheter)
+    finisher.append_finished_projects = [image] * 7
+    finisher.save!(validate: false)
+
+    last_image = finisher.finished_projects.last
+    last_image.purge # remove the last image
+
+    assert finisher.reload.valid?
+  end
 end


### PR DESCRIPTION
## Issue

> Couple of weird errors today. I keep getting an error (Unprocessable Entity) when I try to go into this person's record. https://app.looseendsproject.org/manage/finishers/103998 it happened yesterday and today. And this person https://app.looseendsproject.org/manage/finishers/109265 when I go to update it says Finished Projects files exceed limit, but when I try to delete one, it gives me an error (Not Found).

from [Slack](https://looseendsproject.slack.com/archives/C066WSK1X46/p1750944896243679)

## Cause

It turns out the validation added in #464 was triggering an error on the `manage/finisher/:id` show action. This is because #239 added some backfill that calls `save!` on a Finisher during show. I suspect the delete is also running into an issue where there is one fewer but still too many.

## Fix

This PR changes the validation to only run when `finished_projects` images are changed. This allows other attributes to change on these legacy accounts with too many images. I added model and controller tests for both of these.