### PR TITLE
Make new search UI the default

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -76,7 +76,7 @@ module Manage
       project_view.destroy
       flash[:notice] = "View removed"
 
-      redirect_to manage_projects_path(v2: true)
+      redirect_to manage_projects_path
     end
 
     protected
@@ -103,7 +103,7 @@ module Manage
       return unless load_view_name = params[:load_view]
 
       project_view = current_user.project_views.find(load_view_name)
-      view_params = { v2: true }
+      view_params = {}
       project_view.query.each do |query_predicate|
         view_params[query_predicate["field"]] = query_predicate["value"]
       end
@@ -118,7 +118,7 @@ module Manage
       query_params = params.permit(SAVED_QUERY_PARAMS).to_h
       if query_params.empty?
         flash[:notice] = "Cannot save an empty query view"
-        redirect_to manage_projects_path(v2: true)
+        redirect_to manage_projects_path
         return
       end
 
@@ -128,7 +128,7 @@ module Manage
       flash[:notice] = "View saved as #{new_view_name}"
 
       # Redirect to the new view to avoid leaving it in the URL when parameters are changed
-      redirect_to manage_projects_path(v2: true, load_view: project_view.id)
+      redirect_to manage_projects_path(load_view: project_view.id)
     end
 
     def project_params

--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -21,6 +21,7 @@ module Manage
         format.html do
           @projects = @projects.paginate(page: params[:page], per_page: params[:per_page])
           @status_options_for_select = status_options_for_select
+          @country_options_for_select = country_options_for_select
         end
       end
     end
@@ -97,6 +98,15 @@ module Manage
                        ""
                      end}", status]
       end
+    end
+
+    def country_options_for_select
+      @project_countries = Project.distinct.pluck(:country).compact_blank.sort
+      @countries = ISO3166::Country.all.select do |c|
+        @project_countries.include?(c.alpha2)
+      end
+      @countries.map { |c| [c.iso_short_name, c.alpha2] }
+                .sort_by { |c| I18n.transliterate(c[0]) }
     end
 
     def redirect_to_saved_view

--- a/app/javascript/controllers/search_predicate_controller.js
+++ b/app/javascript/controllers/search_predicate_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ['field', 'operator', 'value', 'predicate']
+  static values = { multiple: Boolean }
 
   connect() {
     this.refresh(true)
@@ -17,6 +18,11 @@ export default class extends Controller {
     }
 
     this.predicateTarget.name = field.toLowerCase()
+    console.log(field, this.multipleValue)
+    if (this.multipleValue) {
+      this.predicateTarget.name += '[]'
+    }
+
     if (value) {
       this.updatePredicate(operator, value)
       this.valueTarget.style.width = `${valueName.length + 2}ch`

--- a/app/views/manage/projects/_search.html.haml
+++ b/app/views/manage/projects/_search.html.haml
@@ -1,8 +1,10 @@
 = form_tag [:manage, :projects], :method => :get, data: { turbo: false } do
+  = hidden_field_tag :v1, true
   = hidden_field_tag :sort, params[:sort]
   .row
-    .col
+    .col-auto
       Search
+    .col.text-end.small= link_to 'New Search', manage_projects_path()
   .row.mb-2
     .col
       = text_field_tag :search, params[:search], class: 'form-control', autocomplete: "off", placeholder: 'Names, Descriptions, Craft Type, Cities, etc.'

--- a/app/views/manage/projects/_search_filters_menu.html.haml
+++ b/app/views/manage/projects/_search_filters_menu.html.haml
@@ -26,3 +26,10 @@
         - date_options.each do |opt_name, opt_value|
           %li
             = link_to("after #{opt_name}", manage_projects_path(request.query_parameters.merge(last_contacted_at: "after(#{opt_value})")), class: 'dropdown-item')
+    .dropend
+      .dropdown-item.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-bs-toggle" => "dropdown", type: "button"}
+        Country
+      %ul.dropdown-menu
+        - @country_options_for_select.each do |country_name, country_code|
+          %li
+            = link_to(country_name, manage_projects_path(request.query_parameters.merge(country: country_code)), class: 'dropdown-item')

--- a/app/views/manage/projects/_search_filters_menu.html.haml
+++ b/app/views/manage/projects/_search_filters_menu.html.haml
@@ -15,7 +15,7 @@
       %ul.dropdown-menu
         - statuses.each do |status|
           %li
-            = link_to(status, manage_projects_path(request.query_parameters.merge(status: status)), class: 'dropdown-item')
+            = link_to(status, manage_projects_path(request.query_parameters.merge(status: [status, request.query_parameters['status']].flatten.compact)), class: 'dropdown-item')
     .dropend
       .dropdown-item.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-bs-toggle" => "dropdown", type: "button"}
         Last Contact Date

--- a/app/views/manage/projects/_search_predicate.html.haml
+++ b/app/views/manage/projects/_search_predicate.html.haml
@@ -1,7 +1,8 @@
 - multiple_choice = local_assigns[:values].present?
+- allow_multiple = local_assigns[:allow_multiple] ? 'true' : 'false'
 - date_field = field.ends_with?('_at')
 - field_name = field.to_s.sub(/(_at|_id)/, '').titleize
-.search-predicate{ data: { controller: 'search-predicate' } }
+.search-predicate{ data: { controller: 'search-predicate', :'search-predicate-multiple-value' => allow_multiple } }
   .field
     %input{ type: :hidden, data: { 'search-predicate-target': 'field', action: 'search-predicate#refresh' }, value: field }
     %span= field_name

--- a/app/views/manage/projects/_search_v2.html.haml
+++ b/app/views/manage/projects/_search_v2.html.haml
@@ -21,7 +21,8 @@
       - if params[:manager_id].present?
         = render partial: 'search_predicate', locals: { field: :manager_id, operator: '=', values: manager_options, value: params[:manager_id] }
       - if params[:status].present?
-        = render partial: 'search_predicate', locals: { field: :status, operator: '=', values: Project::STATUSES.values, value: params[:status] }
+        - Array(params[:status]).each do |status_value|
+          = render partial: 'search_predicate', locals: { field: :status, operator: '=', values: Project::STATUSES.values, value: status_value, allow_multiple: true }
       - if params[:country].present?
         = render partial: 'search_predicate', locals: { field: :country, operator: '=', values: @country_options_for_select, value: params[:country] }
       - if params[:last_contacted_at].present? && params[:last_contacted_at] =~ /^(before|after)\((\d+)\)$/

--- a/app/views/manage/projects/_search_v2.html.haml
+++ b/app/views/manage/projects/_search_v2.html.haml
@@ -22,6 +22,8 @@
         = render partial: 'search_predicate', locals: { field: :manager_id, operator: '=', values: manager_options, value: params[:manager_id] }
       - if params[:status].present?
         = render partial: 'search_predicate', locals: { field: :status, operator: '=', values: Project::STATUSES.values, value: params[:status] }
+      - if params[:country].present?
+        = render partial: 'search_predicate', locals: { field: :country, operator: '=', values: @country_options_for_select, value: params[:country] }
       - if params[:last_contacted_at].present? && params[:last_contacted_at] =~ /^(before|after)\((\d+)\)$/
         - op = $1
         - dt = $2

--- a/app/views/manage/projects/_search_v2.html.haml
+++ b/app/views/manage/projects/_search_v2.html.haml
@@ -5,12 +5,12 @@
     %strong Saved Views:
     - current_user.project_views.each do |project_view|
       .saved-view.btn-group
-        = link_to project_view.name, %Q[?v2=true&load_view=#{project_view.id}], class: 'btn btn-sm btn-outline-secondary saved-view-name'
+        = link_to project_view.name, %Q[load_view=#{project_view.id}], class: 'btn btn-sm btn-outline-secondary saved-view-name'
         .remove.btn.btn-sm.btn-outline-secondary
           = button_to(' ', saved_view_remove_manage_projects_path(remove_view: project_view.id), class: 'btn btn-sm btn-close')
 = form_tag [:manage, :projects], method: :get, data: { turbo: false } do
-  = hidden_field_tag :v2, true
   = hidden_field_tag :sort, params[:sort]
+  .text-end.small= link_to 'Old Search', manage_projects_path(v1: true)
   .search-row
     = text_field_tag :search, params[:search], class: 'form-control', autocomplete: "off", placeholder: 'Names, Descriptions, Craft Type, Cities, etc.'
   .search-row.d-flex

--- a/app/views/manage/projects/index.html.haml
+++ b/app/views/manage/projects/index.html.haml
@@ -3,10 +3,10 @@
   = link_to 'New Project', [:new, :manage, :project], class: 'btn btn-outline-secondary float-end'
 
 .mb-4
-  - if params[:v2]
-    = render 'search_v2'
-  - else
+  - if params[:v1]
     = render 'search'
+  - else
+    = render 'search_v2'
 
 .row#search-results
   - if params[:view] == 'list'

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -260,6 +260,12 @@ module Manage
       assert_search_no_results(manager_id: "0")
     end
 
+    test "search by country" do
+      result = create_search_project
+
+      assert_search_results([result], country: "US")
+    end
+
     test "search with manager_id=none returns projects without manager" do
       result = create_search_project
       result.update!(manager: nil)

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -79,7 +79,7 @@ one:
   city: Anytown
   state: WA
   postal_code: 12345
-  country: USA
+  country: US
   manager_id: 3
   inbound_email_address: project-7a37vorf@localhost
   created_at: <%= 8.days.ago %>


### PR DESCRIPTION
Change the project search to use #387 the default, leaving the old search UI. I confirmed with managers this new UI with saved searches works _but_ I hedged that bet by leaving the old UI. Once we've switched and confirmed it does indeed work I'll go back and remove the old UI.

To handle one feature lost in the change this PR adds country as a filter option. It also adds the ability to select more than one status (so: `INTRODUCED or FINISHED`, stuff like that).

## Old

<img width="2564" height="922" alt="old_search" src="https://github.com/user-attachments/assets/b363a182-b701-4758-867f-9b3b1b41a303" />

## New

<img width="2564" height="922" alt="new_search" src="https://github.com/user-attachments/assets/f78ddc63-d9f4-41df-9c2c-b194c72c5b97" />

