### PR TITLE
Send project checkin emails 'from' manager

### DIFF
--- a/app/mailers/finisher_mailer.rb
+++ b/app/mailers/finisher_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class FinisherMailer < ApplicationMailer
-
   after_deliver :record_delivery
 
   # resource: @finisher
@@ -25,10 +24,22 @@ class FinisherMailer < ApplicationMailer
   # resource: @assignment
   def project_check_in
     @message.set_sgid!(redirect_to: "/assignment/#{@resource.id}/check_in",
-      expires_in: @expires_in)
+                       expires_in: @expires_in)
     mail(
       to: @resource.finisher.user.email,
-      subject: "Tell us how #{@resource.project.name} is going"
+      subject: "Tell us how #{@resource.project.name} is going",
+      reply_to: assignment_reply_to_email(@resource)
     )
+  end
+
+  private
+
+  def assignment_reply_to_email(assignment)
+    manager = assignment.project.manager
+    if manager.present?
+      email_address_with_name(manager.email, manager.name)
+    else
+      "info@looseendsproject.org"
+    end
   end
 end

--- a/test/mailers/finisher_mailer_test.rb
+++ b/test/mailers/finisher_mailer_test.rb
@@ -18,6 +18,7 @@ class FinisherMailerTest < ActionMailer::TestCase
     assert_equal "Loose Ends Project Account Created - Next Steps...", mail.subject
 
     m = @finisher.messages.last
+
     assert_equal "/finisher/new", m.redirect_to
     refute m.single_use
     assert_not_nil m.sgid
@@ -40,6 +41,7 @@ class FinisherMailerTest < ActionMailer::TestCase
     assert_equal "Welcome, Loose Ends Finisher!", mail.subject
 
     m = @finisher.messages.last
+
     refute m.redirect_to
     refute m.single_use
     assert_not_nil m.sgid
@@ -55,8 +57,18 @@ class FinisherMailerTest < ActionMailer::TestCase
 
   test "should send check-in email with magic link" do
     FinisherMailer.with(resource: Assignment.active.first, expires_in: 2.weeks) \
-      .project_check_in.deliver_now
+                  .project_check_in.deliver_now
 
     assert_match "How is it going?", ActionMailer::Base.deliveries.last.body.encoded
+  end
+
+  test "check-in email should have manager's reply-to" do
+    assignment = assignments(:knit_active)
+    manager = assignment.project.manager
+
+    mail = FinisherMailer.with(resource: assignment, expires_in: 2.weeks).project_check_in.deliver_now
+
+    # Note: ActionMailer test parses "Manager Name <manager@email>" and only returns the email part.
+    assert_equal manager.email, mail.reply_to.first
   end
 end


### PR DESCRIPTION
When sending check in emails set the `Reply-To` header to the manager. This does not really send emails _from_ the manager, but anyone hitting **reply** will end up emailing the manager instead of `info@`. I went ahead and did this now so it's a handy example for the upcoming ["Project offer" email](https://looseendsproject.slack.com/archives/C05GUDK4620/p1752861130090349).