### PR TITLE
project_counts report

### DIFF
--- a/app/controllers/manage/reports_controller.rb
+++ b/app/controllers/manage/reports_controller.rb
@@ -38,4 +38,12 @@ class Manage::ReportsController < Manage::ManageController
     render json: Finisher.where("created_at > ?",
       Time.zone.now - 12.months).group_by_month(:created_at).count
   end
+
+  def project_counts
+    @description = "Counts of Projects by Status"
+    @columns = %w(status count)
+    @results = Project.group(:status).count
+    @results["TOTAL"] = Project.count
+    render 'show'
+  end
 end

--- a/app/views/manage/reports/index.html.haml
+++ b/app/views/manage/reports/index.html.haml
@@ -11,3 +11,5 @@
     %h3 Other Reports
     %ul
       %li= link_to "Heard About Us", manage_reports_heard_about_us_path
+    %ul
+      %li= link_to "Project Counts", manage_reports_project_counts_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
       get "active_projects_by_status"
       get "new_projects_by_month"
       get "new_finishers_by_month"
+      get "project_counts"
     end
   end
 

--- a/test/controllers/manage/reports_controller_test.rb
+++ b/test/controllers/manage/reports_controller_test.rb
@@ -14,7 +14,8 @@ class Manage::ReportsControllerTest < ActionController::TestCase
   test "endpoints" do
     [
       :heard_about_us, :active_projects_by_status,
-      :new_projects_by_month, :new_finishers_by_month
+      :new_projects_by_month, :new_finishers_by_month,
+      :project_counts
     ].each do |endpoint|
       get endpoint
       assert_response :success


### PR DESCRIPTION
Added a simple report to show counts of projects by status with TOTAL row.  Example: 

<img width="1087" height="715" alt="image" src="https://github.com/user-attachments/assets/612d74cc-b043-4be6-b01c-f8e5293906c5" />
