### PR TITLE
Fix broken link for saved searches

### DIFF
--- a/app/views/manage/projects/_search_v2.html.haml
+++ b/app/views/manage/projects/_search_v2.html.haml
@@ -5,7 +5,7 @@
     %strong Saved Views:
     - current_user.project_views.each do |project_view|
       .saved-view.btn-group
-        = link_to project_view.name, %Q[load_view=#{project_view.id}], class: 'btn btn-sm btn-outline-secondary saved-view-name'
+        = link_to project_view.name, %Q[?load_view=#{project_view.id}], class: 'btn btn-sm btn-outline-secondary saved-view-name'
         .remove.btn.btn-sm.btn-outline-secondary
           = button_to(' ', saved_view_remove_manage_projects_path(remove_view: project_view.id), class: 'btn btn-sm btn-close')
 = form_tag [:manage, :projects], method: :get, data: { turbo: false } do

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -331,6 +331,14 @@ module Manage
       assert_select "table.project-table"
     end
 
+    test "load_view=id redirects to show" do
+      saved_view = @user.project_views.create!(name: "test", query: [{ field: "foo", value: "bar" }])
+      sign_in @user
+      get "/manage/projects", params: { load_view: saved_view.id }
+
+      assert_redirected_to manage_projects_path(foo: "bar")
+    end
+
     private
 
     def create_search_project # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
## Problem

> Click on a saved search: Not Found The page you were looking for doesn’t exist. You may have mistyped the address or the page may have moved. If you’re the application owner check the logs for more information.

[Slack](https://looseendsproject.slack.com/archives/C05GUDK4620/p1754596906316859)

## Solution

It turns out the URL for the saved search should be `?load_view=id` but was `load_view=id` (no `?`). I added that as well as a test.