### PR TITLE
Project after_save callback to set assignment last_contacted_at

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -122,6 +122,7 @@ class Project < ApplicationRecord
   has_many_attached :material_images
 
   before_validation :set_default_status
+  after_save :set_last_contacted_at
 
   validates :status, inclusion: { in: STATUSES.values }
   validates :dominant_hand, inclusion: { in: DOMINANT_HAND }
@@ -160,6 +161,13 @@ class Project < ApplicationRecord
 
   def set_default_status
     self.status ||= "PROPOSED"
+  end
+
+  def set_last_contacted_at
+    if status == STATUSES[:in_process_underway]
+      assignments.where(status: Assignment::STATUSES[:accepted],
+        last_contacted_at: nil).update_all(last_contacted_at: Time.zone.now)
+    end
   end
 
   def finisher

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -224,6 +224,15 @@ class ProjectTest < ActiveSupport::TestCase
     assert_not_equal(original_updated_at, @project.updated_at)
   end
 
+  test "setting status to IN PROCESS: UNDERWAY sets assignment last_contacted_at" do
+    assert_equal "PROPOSED", @project.status
+    @project.assignments.update_all(last_contacted_at: nil)
+    assert_equal 0, @project.assignments.where.not(last_contacted_at: nil).count
+
+    @project.update(status: Project::STATUSES[:in_process_underway])
+    assert_equal 0,@project.assignments.where(last_contacted_at: nil).count
+  end
+
   test "has messages" do
     assert_nothing_raised { @project.messages }
   end


### PR DESCRIPTION
Assignment `last_contacted_at` starts out as nil.  If a Finisher ignores every check-in email (or doesn't receive them), the Assignment will never be escalated to Needs Attention -> Finisher Unresponsive.  This PR adds an after_save callback on Project to set last_contacted_at on all of that Project's accepted assignments with nil last_contacted_at times.