### PR TITLE
Fix issue with saved searches not saving

### DIFF
--- a/app/controllers/manage/projects_controller.rb
+++ b/app/controllers/manage/projects_controller.rb
@@ -7,8 +7,6 @@ module Manage
     before_action :redirect_to_saved_view, only: :index
     before_action :save_view_by_name, only: :index
 
-    SAVED_QUERY_PARAMS = %i[manager_id status last_contacted_at search view sort].freeze
-
     def index
       @title = "Loose Ends - Manage - Projects"
       @projects = Project.search(params)
@@ -125,7 +123,8 @@ module Manage
 
       new_view_name = params[:save_view].strip
 
-      query_params = params.permit(SAVED_QUERY_PARAMS).to_h
+      query_params = params.permit(:manager_id, :last_contacted_at, :country,
+                                   :search, :view, :sort, status: []).to_h
       if query_params.empty?
         flash[:notice] = "Cannot save an empty query view"
         redirect_to manage_projects_path

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -331,7 +331,7 @@ module Manage
       assert_select "table.project-table"
     end
 
-    test "Can save a view by status" do
+    test "can save a view search by status" do
       sign_in @user
       get "/manage/projects", params: {
         save_view: "test-view",
@@ -344,7 +344,21 @@ module Manage
       assert_equal 1, @user.project_views.where(name: "test-view").count
     end
 
-    test "Can save a view by country" do
+    test "can save a view search by multiple statuses" do
+      sign_in @user
+      get "/manage/projects", params: {
+        save_view: "test-view-multi",
+        status: [Project::STATUSES[:ready_to_match_new], Project::STATUSES[:ready_to_match_additional_attempt]]
+      }
+
+      assert_response :redirect
+      @user.reload
+
+      saved_view = @user.project_views.where(name: "test-view-multi").first.query
+      assert saved_view.any? { |q| q["value"] == [Project::STATUSES[:ready_to_match_new], Project::STATUSES[:ready_to_match_additional_attempt]] }
+    end
+
+    test "can save a view search by country" do
       sign_in @user
       get "/manage/projects", params: {
         save_view: "test-view-us",

--- a/test/controllers/manage/projects_controller_test.rb
+++ b/test/controllers/manage/projects_controller_test.rb
@@ -331,6 +331,32 @@ module Manage
       assert_select "table.project-table"
     end
 
+    test "Can save a view by status" do
+      sign_in @user
+      get "/manage/projects", params: {
+        save_view: "test-view",
+        status: [Project::STATUSES[:ready_to_match_new]]
+      }
+
+      assert_response :redirect
+      @user.reload
+
+      assert_equal 1, @user.project_views.where(name: "test-view").count
+    end
+
+    test "Can save a view by country" do
+      sign_in @user
+      get "/manage/projects", params: {
+        save_view: "test-view-us",
+        country: "US"
+      }
+
+      assert_response :redirect
+      @user.reload
+
+      assert_equal 1, @user.project_views.where(name: "test-view-us").count
+    end
+
     test "load_view=id redirects to show" do
       saved_view = @user.project_views.create!(name: "test", query: [{ field: "foo", value: "bar" }])
       sign_in @user


### PR DESCRIPTION
Any saved search with a country or project status in the filters was not saving correctly. The root cause as a `permit` call with incomplete parameters. That was caused by saving these in an array when `permit` takes a more complex argument to allow for the description of array params, which we use for statuses. I added controller tests to verify this will continue to work.