### PR TITLE
Export CSV from new project search

### DIFF
--- a/app/views/manage/projects/_search_v2.html.haml
+++ b/app/views/manage/projects/_search_v2.html.haml
@@ -33,3 +33,6 @@
       = select_tag :view, options_for_select([['Show Cards', nil], ['Show List', 'list']], params[:view]), class: 'form-select me-1'
       = render partial: 'search_view_save_menu'
       = submit_tag "Search", name: nil, class: 'btn btn-primary btn-search ms-1'
+      = button_tag(formaction: manage_projects_path(format: 'csv'), class: 'btn btn-sm btn-light ms-2') do
+        %span export csv
+        = fa_icon('file-export')


### PR DESCRIPTION
Adds the basic `export csv` button to the new project search as requested [here](https://looseendsproject.slack.com/lists/T05GP1TRWQM/F07E2EA51B2?record_id=Rec09DRGZ29EK). I will look into adding the ability to select which fields are included in the CSV later.

Video walkthrough:
https://github.com/user-attachments/assets/8e61483f-ccc7-4a66-adce-44fa688f231b
