### PR TITLE
Make check-in email magic link one-time link

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,6 +2,9 @@
 
 module Users
   class SessionsController < Devise::SessionsController
+    # Let magic_link run even when already signed in so we can show "already been used"
+    # instead of Devise's "You are already signed in." redirect to root.
+    skip_before_action :require_no_authentication, only: [:magic_link]
     before_action :ensure_params, only: [:magic_link]
 
     # Sign in user and redirect
@@ -27,6 +30,17 @@ module Users
       def attempt_locate(&block)
         message = GlobalID::Locator.locate_signed(params[:sgid])
         if message.present? && message.user.is_a?(User)
+          unless message.valid_sgid?
+            # If the user is already signed in, show the "already used" message
+            # on a page they are allowed to visit (not the sign-in page, which
+            # Devise will immediately redirect away from with "You are already signed in.")
+            if user_signed_in?
+              redirect_to "/", flash: { alert: "This link has already been used." }
+            else
+              redirect_to "/users/sign_in", flash: { alert: "This link has already been used." }
+            end
+            return true
+          end
           message.increment!(:click_count)
 
           sign_in(message.user)

--- a/app/mailers/finisher_mailer.rb
+++ b/app/mailers/finisher_mailer.rb
@@ -24,7 +24,8 @@ class FinisherMailer < ApplicationMailer
   # resource: @assignment
   def project_check_in
     @message.set_sgid!(redirect_to: "/assignment/#{@resource.id}/check_in",
-                       expires_in: @expires_in)
+                       expires_in: @expires_in,
+                       single_use: true)
     mail(
       to: @resource.finisher.user.email,
       subject: "Tell us how #{@resource.project.name} is going",

--- a/app/views/finisher_mailer/project_check_in.html.haml
+++ b/app/views/finisher_mailer/project_check_in.html.haml
@@ -6,5 +6,8 @@
   class: 'email-button'
 
 %p
+  Please also remember to keep your project owner updated!
+
+%p
   Thank you for being part of this with us,
   .italic= @resource.project.manager.name

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -44,4 +44,18 @@ class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to '/users/sign_in'
     assert_equal "Bad link. Please contact support.", flash[:alert]
   end
+
+  test 'single-use link works once then is rejected' do
+    @message.update_columns(single_use: true, click_count: 0)
+    travel_to @message.expires_at - 1.day
+
+    get "/magic_link", params: { sgid: @message.sgid }
+    assert_redirected_to @message.redirect_to
+    assert_equal 1, @message.reload.click_count
+
+    get "/magic_link", params: { sgid: @message.sgid }
+    assert_redirected_to "/"
+    assert_match "already been used", flash[:alert]
+    assert_equal 1, @message.reload.click_count
+  end
 end

--- a/test/mailers/finisher_mailer_test.rb
+++ b/test/mailers/finisher_mailer_test.rb
@@ -62,6 +62,14 @@ class FinisherMailerTest < ActionMailer::TestCase
     assert_match "How is it going?", ActionMailer::Base.deliveries.last.body.encoded
   end
 
+  test "check-in email magic link is single-use" do
+    assignment = Assignment.active.first
+    FinisherMailer.with(resource: assignment, expires_in: 2.weeks).project_check_in.deliver_now
+
+    m = assignment.messages.last
+    assert m.single_use, "check-in magic link should be single-use"
+  end
+
   test "check-in email should have manager's reply-to" do
     assignment = assignments(:knit_active)
     manager = assignment.project.manager


### PR DESCRIPTION
This PR takes care of two issues in the list:
1. Make the check-in email magic link a one-time link
2. Add "Please also remember to keep your project owner updated!" to the check-in email

Magic link has already been used:
<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/513e85c4-4605-4be3-bdea-0830a36977c5" />

Updated copy in check-in email:
<img width="703" height="486" alt="image" src="https://github.com/user-attachments/assets/703c8ecd-88ba-47d2-b0ff-0db7591a8454" />
