### PR TITLE
Handle last contact date for unresponsive finishers

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -48,6 +48,7 @@ class Assignment < ApplicationRecord
   validates :status, inclusion: { in: STATUSES.values, allow_blank: true }
 
   before_save :sanitize_status
+  before_save :reset_check_in_clock_on_revival
   after_save :denormalize_created_by
 
   def self.active
@@ -128,6 +129,17 @@ class Assignment < ApplicationRecord
 
   def sanitize_status
     self.status = nil if status.blank?
+  end
+
+  # When an assignment is revived from "unresponsive" back to "accepted",
+  # reset the check-in clock so SendCheckInsJob doesn't immediately re-flag it.
+  def reset_check_in_clock_on_revival
+    return unless status_changed? &&
+                  status_was == STATUSES[:unresponsive] &&
+                  status == STATUSES[:accepted]
+
+    self.last_contacted_at = Time.zone.now
+    self.check_in_sent_at = nil
   end
 
   def denormalize_created_by

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -170,9 +170,9 @@ class Project < ApplicationRecord
   end
 
   def set_last_contacted_at
-    if status == STATUSES[:in_process_underway]
-      assignments.where(status: Assignment::STATUSES[:accepted]).update_all(last_contacted_at: Time.zone.now)
-    end
+    return unless saved_change_to_status? && status == STATUSES[:in_process_underway]
+
+    assignments.where(status: Assignment::STATUSES[:accepted]).update_all(last_contacted_at: Time.zone.now)
   end
 
   def finisher

--- a/test/jobs/send_check_ins_job_test.rb
+++ b/test/jobs/send_check_ins_job_test.rb
@@ -48,11 +48,16 @@ class SendCheckInsJobTest < ActiveJob::TestCase
       Time.zone.now.beginning_of_day - Assignment::UNRESPONSIVE_AFTER.weeks)
 
     assert @assignment.missed_check_ins?
+    original_last_contacted_at = @assignment.last_contacted_at
 
     SendCheckInsJob.perform_now
     assert_enqueued_jobs 0
     assert_equal "finisher_unresponsive", @assignment.reload.project.needs_attention
     assert_equal "unresponsive", @assignment.status
     assert_match "UNRESPONSIVE", JobLog.last.output
+    assert_in_delta original_last_contacted_at,
+                    @assignment.last_contacted_at,
+                    1.second,
+                    "Escalation should not overwrite last_contacted_at"
   end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -234,6 +234,28 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 0,@project.assignments.where(last_contacted_at: nil).count
   end
 
+  test "non-status save on UNDERWAY project does not churn last_contacted_at" do
+    @project.update!(status: Project::STATUSES[:in_process_underway])
+    @project.assignments.where(status: Assignment::STATUSES[:accepted]).each do |a|
+      a.update_columns(last_contacted_at: 5.weeks.ago)
+    end
+    timestamps_before = @project.assignments
+                                .where(status: Assignment::STATUSES[:accepted])
+                                .pluck(:id, :last_contacted_at)
+                                .to_h
+
+    travel 1.day do
+      @project.update!(description: "an unrelated edit")
+    end
+
+    timestamps_after = @project.assignments
+                               .where(status: Assignment::STATUSES[:accepted])
+                               .pluck(:id, :last_contacted_at)
+                               .to_h
+    assert_equal timestamps_before, timestamps_after,
+      "last_contacted_at should not change on non-status saves"
+  end
+
   test "has messages" do
     assert_nothing_raised { @project.messages }
   end


### PR DESCRIPTION
Issue, as described by Jean:

As you know, automatic emails send check-in requests every three weeks, flagging contacts as unresponsive after three non-responses

- Bug appears to mark last contact date as the date they're flagged unresponsive, preventing ability to clear the unresponsive status. 
- I can't quite figure this out, but I think the system is also updating Last Contact date to the day anyone used the project email (me or PO). Might be the issue for the last bullet 
- System correctly flags contacts but breaks after that point
- Some contacts (2-3 over past couple months) are receiving emails saying their finisher is unresponsive when the system hasn't flagged them